### PR TITLE
Grant Claude review tools via claude_args

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -29,28 +29,40 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checks:*),Read,Grep,Glob"
           prompt: |
-            Review this pull request for vLLM-OMNI.
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
-            Style rules (strict):
-            - Post 2-6 inline comments MAX. Pick the highest-signal issues only.
-            - Around half of comments should be 1-line (e.g., "Seems unused", "Is this really needed?").
+            Review this vLLM-OMNI pull request. The PR branch is already checked out.
+
+            HOW TO POST COMMENTS (important):
+            - Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true` for inline code comments.
+            - Use `gh pr comment` for a top-level summary comment (only if needed).
+            - Do NOT output review text as chat messages — it will not be posted.
+
+            STYLE RULES (strict):
+            - Post 2-6 inline comments MAX. Only the highest-signal issues.
+            - Around half the comments should be 1-line (e.g., "Seems unused", "Is this really needed?").
             - Do NOT prefix comments with "Nit:" — state the issue directly.
             - Use GitHub ```suggestion blocks for obvious fixes.
-            - No inline praise ("Good placement", "Nice work") — skip it.
+            - No inline praise ("Good placement", "Nice work") — skip it entirely.
             - Be direct: "Why not X?" instead of "Would it make sense to...?"
             - Hedge only when genuinely uncertain ("Tbh I think...").
-            - Review body: keep it ultra-short ("LGTM", "Some nits", "Please fix pre-commit") or leave empty.
-            - About half the time, leave the review body empty and only post inline comments.
+            - Summary comment: keep it ultra-short ("LGTM", "Some nits", "Please fix pre-commit") or skip it.
+            - About half the time, skip the summary and only post inline comments.
 
-            Focus areas (in priority order):
+            FOCUS (priority order):
             1. Correctness bugs (off-by-one, race conditions, wrong dtype/device, missing error handling at boundaries)
             2. API/interface issues (breaking changes, bad naming, inconsistent with existing code)
             3. Performance regressions in hot paths
             4. Test coverage gaps for new logic
 
-            Skip:
+            SKIP:
             - Style nits already caught by pre-commit/ruff
-            - Speculative refactor suggestions
+            - Speculative refactors
             - Documentation wording unless clearly wrong
             - Commenting on every file — only files with real issues
+
+            If the PR is trivial (pure doc/typo/whitespace), post a single 1-line "LGTM" via `gh pr comment` and stop.


### PR DESCRIPTION
Claude was running but hitting 16 permission denials because the workflow didn't declare `claude_args`. Adding `--allowedTools` for `mcp__github_inline_comment__create_inline_comment` + `gh pr comment/diff/view` so the bot can actually post reviews.