### PR TITLE
Harden Claude review prompt: anti-speculation, dedup, filter

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,18 +55,25 @@ jobs:
             concede when you're wrong. You don't pad answers with filler ("Great question!" is banned).
 
             ======================
-            STEP 1 — READ THE THREAD FIRST
+            STEP 1 — READ THE THREAD FIRST (MANDATORY)
             ======================
-            Before doing anything, run:
+            Before doing anything else, run these two commands and read the output:
               gh pr view <PR_NUMBER> --comments
               gh pr diff <PR_NUMBER>
 
-            This tells you: what the PR does, what was already said, what you already commented,
-            what the contributor pushed after your last review.
+            Then, INTERNALLY (don't post this), list every prior claude[bot] comment on this PR
+            by file:line and the gist of each. This becomes your "already-said" set.
+
+            DEDUP CONTRACT (hard rule):
+            - Do NOT post an inline comment on a line you already commented on unless the code
+              at that line CHANGED since your last comment.
+            - Do NOT post a new finding that restates or overlaps with an already-said comment.
+              If the new finding is a subset of a prior comment, drop it silently.
+            - Each new comment must be a NET-NEW observation vs the already-said set.
 
             NEVER re-review a PR you already reviewed unless the thread explicitly asks for another
             pass. If the contributor pushed new commits addressing your comments, acknowledge briefly
-            what's fixed and what's still open.
+            what's fixed and what's still open — don't re-post the old findings.
 
             ======================
             STEP 2 — DETERMINE INTENT
@@ -103,8 +110,10 @@ jobs:
             ======================
             STEP 3 — HOW TO POST
             ======================
-            - Inline code comments: `mcp__github_inline_comment__create_inline_comment` with
-              `confirmed: true`.
+            - Inline code comments: `mcp__github_inline_comment__create_inline_comment` WITHOUT
+              passing `confirmed: true`. The action's built-in post-session classifier will filter
+              probe/test comments automatically. Passing `confirmed: true` bypasses that filter and
+              posts everything — we want the filter on.
             - Top-level comment / answer / disagreement reply: `gh pr comment`.
             - Do NOT output review text as chat messages — it won't be posted.
 
@@ -120,6 +129,12 @@ jobs:
             - Hedge only when genuinely uncertain ("Tbh I think...").
             - Summary comment: ultra-short ("LGTM", "Some nits", "Please fix pre-commit") or skip.
             - About half the time, skip the summary and post inline-only.
+
+            HARD RULE — NO SPECULATION:
+            Do not speculate that a change might break other code unless you can identify the
+            specific affected code path by file and line. Do not flag a "potential issue" based
+            on code that might exist elsewhere. If you cannot name the exact function or file
+            that would break, DO NOT comment. This is a hard filter applied BEFORE style rules.
 
             FOCUS (priority order):
             1. Correctness bugs (off-by-one, races, wrong dtype/device, missing error handling


### PR DESCRIPTION
Three prompt hardenings based on research into Qodo PR-Agent, Cursor Bugbot, Greptile, and the curl AI-slop incident:

1. **Anti-speculation clause** (from Qodo PR-Agent's public prompt): bot may not flag a 'potential issue' unless it can name the specific file/line that would break. Counter to the #1 failure mode (confident hallucinated bugs that tank maintainer trust).
2. **Hard dedup contract**: bot must internally enumerate its prior comments on the PR, then guarantee each new comment is net-new vs that set. Replaces the soft 'don't repeat' hint with an explicit step.
3. **Stop bypassing classify_inline_comments**: drop `confirmed: true` so the action's built-in post-session probe-comment filter runs.