### PR TITLE
[Test] distilled LoRA for diffusion (upstream #2783 mirror, rebased)

### DIFF
--- a/examples/offline_inference/text_to_video/text_to_video.py
+++ b/examples/offline_inference/text_to_video/text_to_video.py
@@ -12,6 +12,8 @@ import torch
 from vllm_omni.diffusion.data import DiffusionParallelConfig
 from vllm_omni.entrypoints.omni import Omni
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams
+from vllm_omni.lora.request import LoRARequest
+from vllm_omni.lora.utils import stable_lora_int_id
 from vllm_omni.outputs import OmniRequestOutput
 from vllm_omni.platforms import current_omni_platform
 
@@ -185,6 +187,18 @@ def parse_args() -> argparse.Namespace:
         choices=["fp8", "gguf"],
         help="Quantization method for the transformer (fp8 for online FP8 quantization).",
     )
+    parser.add_argument(
+        "--lora-path",
+        type=str,
+        default=None,
+        help="Path to LoRA adapter folder (PEFT format). Loaded at initialization and used for generation.",
+    )
+    parser.add_argument(
+        "--lora-scale",
+        type=float,
+        default=1.0,
+        help="Scale factor for LoRA weights (default: 1.0).",
+    )
     return parser.parse_args()
 
 
@@ -250,6 +264,8 @@ def main():
         omni_kwargs["cache_backend"] = args.cache_backend
         omni_kwargs["cache_config"] = cache_config
         omni_kwargs["enable_cache_dit_summary"] = args.enable_cache_dit_summary
+    if args.lora_path is not None:
+        omni_kwargs["lora_path"] = args.lora_path
 
     omni = Omni(**omni_kwargs)
 
@@ -271,9 +287,23 @@ def main():
     print(f"  Video size: {args.width}x{args.height}")
     print(f"{'=' * 60}\n")
 
+    lora_request = None
+    if args.lora_path:
+        lora_request_id = stable_lora_int_id(args.lora_path)
+        lora_request = LoRARequest(
+            lora_name=Path(args.lora_path).stem,
+            lora_int_id=lora_request_id,
+            lora_path=args.lora_path,
+        )
+
     prompt_dict = {"prompt": args.prompt}
     if args.negative_prompt:
         prompt_dict["negative_prompt"] = args.negative_prompt
+
+    extra_args = {}
+    if lora_request:
+        extra_args["lora_request"] = lora_request
+        extra_args["lora_scale"] = args.lora_scale
 
     sampling_kwargs = dict(
         height=args.height,
@@ -282,6 +312,7 @@ def main():
         guidance_scale=args.guidance_scale,
         num_inference_steps=args.num_inference_steps,
         num_frames=args.num_frames,
+        extra_args=extra_args,
     )
     if args.guidance_scale_high is not None:
         sampling_kwargs["guidance_scale_2"] = args.guidance_scale_high

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -16,8 +16,6 @@ from vllm_omni.diffusion.utils.tf_utils import find_module_with_attr, get_transf
 
 logger = init_logger(__name__)
 
-LORA_DIFFUSERS_CONVERTER_REGISTRY = {}
-
 lora_convert_mapping: dict[str, Callable] = {
     "LTX2Pipeline": _convert_non_diffusers_ltx2_lora_to_diffusers,
     "QwenImagePipeline": _convert_non_diffusers_qwen_lora_to_diffusers,

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -101,51 +101,10 @@ def _remap_state_dict_keys(sd, rules):
     return new_sd
 
 
-class QwenImageLoraLoaderMixin:
+class LoraLoaderMixin:
     transformer_name = "transformer"
     lora_loaded = set()
     lora_loaded_deltas = {}
-
-    def load_lora_weights(
-        self,
-        pretrained_model_name_or_path: str,
-        adapter_name: str | None = None,
-    ):
-        if adapter_name in self.lora_loaded:
-            return
-        self.lora_loaded.add(adapter_name)
-
-        state_dict = _load_lora_state_dict(pretrained_model_name_or_path)
-
-        has_alpha = any(k.endswith(".alpha") for k in state_dict)
-        is_non_diffusers_format = any(k.startswith("diffusion_model.") for k in state_dict)
-        if has_alpha or is_non_diffusers_format:
-            converter = get_converter_by_pipeline(self)
-            if converter is None:
-                raise ValueError(f"Converter for Lora weights not found for {self.__class__.__name__}")
-
-            state_dict = converter(state_dict)
-
-        state_dict = _remap_state_dict_keys(state_dict, [(".to_out.0.", ".to_out.")])
-
-        lora_deltas = self.load_lora_into_module(
-            state_dict,
-            self.transformer,
-            prefix=self.transformer_name,
-        )
-
-        self.lora_loaded_deltas[adapter_name] = lora_deltas
-
-    def unload_lora_weights(self, adapter_name: str):
-        if adapter_name not in self.lora_loaded:
-            return
-        lora_deltas = self.lora_loaded_deltas[adapter_name]
-
-        transformer = get_transformer_from_pipeline(self)
-        self.unload_module_lora(transformer, lora_deltas, prefix=self.transformer_name)
-
-        self.lora_loaded.remove(adapter_name)
-        del self.lora_loaded_deltas[adapter_name]
 
     @classmethod
     def load_lora_into_module(
@@ -248,8 +207,9 @@ class QwenImageLoraLoaderMixin:
 
         return lora_deltas
 
+    @classmethod
     def unload_module_lora(
-        self,
+        cls,
         module,
         lora_deltas,
         prefix: str = "transformer",
@@ -270,7 +230,54 @@ class QwenImageLoraLoaderMixin:
         logger.info(f"Unload {lora_key_unload_count} lora keys from {module.__class__.__name__}.")
 
 
-class LTX2LoraLoaderMinxin:
+class QwenImageLoraLoaderMixin(LoraLoaderMixin):
+    transformer_name = "transformer"
+    lora_loaded = set()
+    lora_loaded_deltas = {}
+
+    def load_lora_weights(
+        self,
+        pretrained_model_name_or_path: str,
+        adapter_name: str | None = None,
+    ):
+        if adapter_name in self.lora_loaded:
+            return
+        self.lora_loaded.add(adapter_name)
+
+        state_dict = _load_lora_state_dict(pretrained_model_name_or_path)
+
+        has_alpha = any(k.endswith(".alpha") for k in state_dict)
+        is_non_diffusers_format = any(k.startswith("diffusion_model.") for k in state_dict)
+        if has_alpha or is_non_diffusers_format:
+            converter = get_converter_by_pipeline(self)
+            if converter is None:
+                raise ValueError(f"Converter for Lora weights not found for {self.__class__.__name__}")
+
+            state_dict = converter(state_dict)
+
+        state_dict = _remap_state_dict_keys(state_dict, [(".to_out.0.", ".to_out.")])
+
+        lora_deltas = self.load_lora_into_module(
+            state_dict,
+            self.transformer,
+            prefix=self.transformer_name,
+        )
+
+        self.lora_loaded_deltas[adapter_name] = lora_deltas
+
+    def unload_lora_weights(self, adapter_name: str):
+        if adapter_name not in self.lora_loaded:
+            return
+        lora_deltas = self.lora_loaded_deltas[adapter_name]
+
+        transformer = get_transformer_from_pipeline(self)
+        self.unload_module_lora(transformer, lora_deltas, prefix=self.transformer_name)
+
+        self.lora_loaded.remove(adapter_name)
+        del self.lora_loaded_deltas[adapter_name]
+
+
+class LTX2LoraLoaderMinxin(LoraLoaderMixin):
     transformer_name = "transformer"
     connectors_name = "connectors"
 
@@ -338,125 +345,3 @@ class LTX2LoraLoaderMinxin:
 
         self.lora_loaded.remove(adapter_name)
         del self.lora_loaded_deltas[adapter_name]
-
-    @classmethod
-    def load_lora_into_module(
-        cls,
-        state_dict,
-        module,
-        prefix: str = "transformer",
-    ):
-        lora_deltas = {}
-        lora_a_suffix = "lora_A.weight"
-        lora_b_suffix = "lora_B.weight"
-
-        # handle stacked QKV fusion
-        stacked_sd = defaultdict(list)
-        for key, param in state_dict.items():
-            base_key = key[: -len(f".{lora_a_suffix}")]
-            is_stacked_param = False
-            if hasattr(module, "stacked_params_mapping"):
-                # attn1.to_q.lora_A.weight
-                #                           => attn1.to_q => attn1.to_q.delta
-                # attn1.to_q.lora_B.weight
-                for param_name, weight_name, _ in module.stacked_params_mapping:
-                    if weight_name not in key:
-                        continue
-                    is_stacked_param = True
-                    if key.endswith(lora_a_suffix):
-                        a = param
-                        b = state_dict[f"{base_key}.{lora_b_suffix}"]
-                        delta = torch.matmul(b, a)
-                        stacked_base_key = key.replace(weight_name, param_name)[: -len(f".{lora_a_suffix}")]
-                        stacked_sd[stacked_base_key].append(delta)
-
-                if is_stacked_param:
-                    continue
-
-                if key.endswith(lora_a_suffix):
-                    a = param
-                    b = state_dict[f"{base_key}.{lora_b_suffix}"]
-                    delta = torch.matmul(b, a)
-                    lora_deltas[base_key] = delta
-            else:
-                if key.endswith(lora_a_suffix):
-                    a = param
-                    b = state_dict[f"{base_key}.{lora_b_suffix}"]
-                    delta = torch.matmul(b, a)
-                    lora_deltas[base_key] = delta
-
-        for stacked_base_key, delta_list in stacked_sd.items():
-            stacked_delta = torch.concat(delta_list)
-            lora_deltas[stacked_base_key] = stacked_delta
-
-        lora_loaded_keys = set()
-        lora_key_loaded_count = 0
-        for name, params in module.named_parameters(prefix):
-            if not name.endswith(".weight"):
-                continue
-
-            base_key = name[: -len(".weight")]
-            lora_a_key = f"{base_key}.{lora_a_suffix}"
-            lora_b_key = f"{base_key}.{lora_b_suffix}"
-
-            if base_key not in lora_deltas:
-                continue
-
-            delta = lora_deltas[base_key].to(device=params.device, dtype=params.dtype)
-            params.add_(delta)
-            lora_key_loaded_count += 1
-            del delta
-
-            is_stacked_param = False
-            if hasattr(module, "stacked_params_mapping"):
-                for param_name, weight_name, _ in module.stacked_params_mapping:
-                    if param_name not in base_key:
-                        continue
-                    is_stacked_param = True
-                    lora_a_key = f"{base_key.replace(param_name, weight_name)}.{lora_a_suffix}"
-                    lora_b_key = f"{base_key.replace(param_name, weight_name)}.{lora_b_suffix}"
-
-                    if lora_a_key in state_dict:
-                        lora_loaded_keys.add(lora_a_key)
-                    else:
-                        logger.warning(f"Failed to index lora key {lora_a_key}")
-                    if lora_b_key in state_dict:
-                        lora_loaded_keys.add(lora_b_key)
-                    else:
-                        logger.warning(f"Failed to index lora key {lora_b_key}")
-
-                if not is_stacked_param:
-                    lora_loaded_keys.add(lora_a_key)
-                    lora_loaded_keys.add(lora_b_key)
-            else:
-                lora_loaded_keys.add(lora_a_key)
-                lora_loaded_keys.add(lora_b_key)
-
-        for k in state_dict:
-            if k not in lora_loaded_keys:
-                logger.warning(f"Missing loading lora key: {k}")
-
-        logger.info(f"{lora_key_loaded_count} lora keys loaded into {module.__class__.__name__}.")
-
-        return lora_deltas
-
-    def unload_module_lora(
-        self,
-        module,
-        lora_deltas,
-        prefix: str = "transformer",
-    ):
-        lora_key_unload_count = 0
-        for name, param in module.named_parameters(prefix):
-            if not name.endswith(".weight"):
-                continue
-
-            base_key = name[: -len(".weight")]
-            if base_key not in lora_deltas:
-                continue
-
-            delta = lora_deltas[base_key].to(device=param.device, dtype=param.dtype)
-            param.sub_(delta)
-            lora_key_unload_count += 1
-
-        logger.info(f"Unload {lora_key_unload_count} lora keys from {module.__class__.__name__}.")

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -6,6 +6,7 @@ import torch
 from diffusers.loaders.lora_conversion_utils import (
     _convert_non_diffusers_ltx2_lora_to_diffusers,
     _convert_non_diffusers_qwen_lora_to_diffusers,
+    _convert_non_diffusers_wan_lora_to_diffusers,
 )
 from huggingface_hub import hf_hub_download
 from safetensors.torch import load_file
@@ -22,6 +23,8 @@ lora_convert_mapping: dict[str, Callable] = {
     "QwenImagePipeline": _convert_non_diffusers_qwen_lora_to_diffusers,
     "QwenImageEditPipeline": _convert_non_diffusers_qwen_lora_to_diffusers,
     "QwenImageEditPlusPipeline": _convert_non_diffusers_qwen_lora_to_diffusers,
+    "Wan22Pipeline": _convert_non_diffusers_wan_lora_to_diffusers,
+    "Wan22I2VPipeline": _convert_non_diffusers_wan_lora_to_diffusers,
 }
 
 
@@ -360,3 +363,98 @@ class LTX2LoraLoaderMinxin(LoraLoaderMixin):
 
         self.lora_loaded.remove(adapter_name)
         del self.lora_loaded_deltas[adapter_name]
+
+
+class WanLoraLoaderMixin(LoraLoaderMixin):
+    supported_ckpt_mapping = {
+        "wan2.2_i2v_A14b_high_noise_lora_rank64_lightx2v_4step_1022.safetensors": "transformer",
+        "wan2.2_i2v_A14b_low_noise_lora_rank64_lightx2v_4step_1022.safetensors": "transformer_2",
+        "wan2.2_t2v_A14b_high_noise_lora_rank64_lightx2v_4step_1217.safetensors": "transformer",
+        "wan2.2_t2v_A14b_low_noise_lora_rank64_lightx2v_4step_1217.safetensors": "transformer_2",
+        "high_noise_model.safetensors": "transformer",
+        "low_noise_model.safetensors": "transformer_2",
+    }
+
+    def load_lora_weights(
+        self,
+        pretrained_model_name_or_path: str,
+        adapter_name: str | None = None,
+    ):
+        if adapter_name in self.lora_loaded:
+            return
+        self.lora_loaded.add(adapter_name)
+
+        cls_name = self.__class__.__name__
+        task = "i2v" if "I2V" in cls_name else "t2v"
+
+        lora_paths = self._get_target_lora_paths(pretrained_model_name_or_path, self.has_transformer_2, task=task)
+        for lora_path in lora_paths:
+            state_dict = _load_lora_state_dict(lora_path)
+            is_non_diffusers_format = any(k.startswith("diffusion_model.") for k in state_dict)
+            if is_non_diffusers_format:
+                converter = get_converter_by_pipeline(self)
+                if converter is None:
+                    raise ValueError(f"Converter for Lora weights not found for {self.__class__.__name__}")
+
+                state_dict = converter(state_dict)
+
+            state_dict = _remap_state_dict_keys(
+                state_dict,
+                [
+                    (".ffn.net.0.", ".ffn.net_0."),
+                    (".ffn.net.2.", ".ffn.net_2."),
+                    (
+                        ".to_out.0.",
+                        ".to_out.",
+                    ),
+                ],
+            )
+
+            if self.has_transformer_2:
+                # wan22 load path
+                filename = os.path.basename(lora_path)
+                target_module_name = self.supported_ckpt_mapping[filename]
+                module = getattr(find_module_with_attr(self, target_module_name), target_module_name)
+                self.load_lora_into_module(state_dict, module, prefix=self.transformer_name)
+            else:
+                # wan21 load path
+                self.load_lora_into_module(state_dict, self.transformer, prefix=self.transformer_name)
+
+    def unload_lora_weights(self, adapter_name: str):
+        if adapter_name not in self.lora_loaded:
+            return
+        lora_deltas = self.lora_loaded_deltas[adapter_name]
+
+        transformer = get_transformer_from_pipeline(self)
+        self.unload_module_lora(transformer, lora_deltas, prefix=self.transformer_name)
+
+        self.lora_loaded.remove(adapter_name)
+        del self.lora_loaded_deltas[adapter_name]
+
+    def _get_target_lora_paths(
+        self,
+        pretrained_model_name_or_path,
+        is_wan22: bool = True,
+        task: str = "t2v",
+    ):
+        lora_paths = []
+        if os.path.isdir(pretrained_model_name_or_path):
+            for filename in os.listdir(pretrained_model_name_or_path):
+                if not filename.endswith(".safetensors"):
+                    continue
+                if filename not in self.supported_ckpt_mapping:
+                    continue
+                if task in filename.lower():
+                    lora_paths.append(os.path.join(pretrained_model_name_or_path, filename))
+
+            return lora_paths
+
+        if is_wan22:
+            raise ValueError("Wan22 distilled LoRA weights are not supported by directory")
+
+        filename = os.path.basename(pretrained_model_name_or_path).lower()
+        if task not in filename:
+            raise ValueError(f"LoRA weights {pretrained_model_name_or_path} is not a {task} LoRA weights")
+
+        lora_paths.append(pretrained_model_name_or_path)
+        return lora_paths

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -363,9 +363,9 @@ class LTX2LoraLoaderMixin(LoraLoaderMixin):
 
             lora_state_dict = converter(state_dict)
 
-        if has_connector:
-            connector_state_dict = converter(state_dict, "text_embedding_projection")
-            lora_state_dict.update(connector_state_dict)
+            if has_connector:
+                connector_state_dict = converter(state_dict, "text_embedding_projection")
+                lora_state_dict.update(connector_state_dict)
 
         transformer_sd = {k: v for k, v in lora_state_dict.items() if k.startswith(self.transformer_name)}
         connectors_sd = {k: v for k, v in lora_state_dict.items() if k.startswith(self.connectors_name)}

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -1,0 +1,251 @@
+import os
+from collections import defaultdict
+from collections.abc import Callable
+
+import torch
+from diffusers.loaders.lora_conversion_utils import (
+    _convert_non_diffusers_ltx2_lora_to_diffusers,
+)
+from huggingface_hub import hf_hub_download
+from safetensors.torch import load_file
+from vllm.logger import init_logger
+
+from vllm_omni.diffusion.utils.tf_utils import find_module_with_attr, get_transformer_from_pipeline
+
+logger = init_logger(__name__)
+
+
+lora_convert_mapping: dict[str, Callable] = {
+    "LTX2Pipeline": _convert_non_diffusers_ltx2_lora_to_diffusers,
+}
+
+
+def _load_lora_state_dict(
+    pretrained_model_name_or_path: str,
+    weights_name: str | None = None,
+    use_safetensors: bool = True,
+    subfolder: str | None = None,
+    cache_dir: str | None = None,
+    force_download: bool = False,
+    local_files_only: bool | None = None,
+):
+    # first we try to load it from local disk
+    if use_safetensors and pretrained_model_name_or_path.endswith(".safetensors"):
+        return load_file(pretrained_model_name_or_path)
+
+    if os.path.isdir(pretrained_model_name_or_path):
+        model_file = pretrained_model_name_or_path
+        if subfolder:
+            model_file = os.path.join(model_file, subfolder)
+        if weights_name is None:
+            raise ValueError("weights_name is required when loading from a directory")
+        model_file = os.path.join(model_file, weights_name)
+        return load_file(model_file)
+
+    # finally, we try to load it from the internet
+    try:
+        model_file = hf_hub_download(
+            pretrained_model_name_or_path,
+            filename=weights_name,
+            subfolder=subfolder,
+            cache_dir=cache_dir,
+            force_download=force_download,
+            local_files_only=local_files_only,
+        )
+        return load_file(model_file)
+    except Exception as e:
+        logger.error(f"Failed to download {weights_name} from {pretrained_model_name_or_path}: {e}")
+        raise e
+
+
+class LTX2LoRALoaderMinxin:
+    transformer_name = "transformer"
+    connectors_name = "connectors"
+
+    lora_loaded = set()
+    lora_loaded_deltas = {}
+
+    def load_lora_weights(
+        self,
+        pretrained_model_name_or_path: str,
+        adapter_name: str | None = None,
+    ):
+        if adapter_name in self.lora_loaded:
+            return
+        self.lora_loaded.add(adapter_name)
+
+        state_dict = _load_lora_state_dict(pretrained_model_name_or_path)
+
+        lora_state_dict = state_dict
+        is_non_diffusers_format = any(k.startswith("diffusion_model.") for k in state_dict)
+        has_connector = any(k.startswith("text_embedding_projection.") for k in state_dict)
+
+        if is_non_diffusers_format:
+            cls_name = self.__class__.__name__
+            converter = lora_convert_mapping.get(cls_name, None)
+            if converter is None:
+                raise ValueError(f"Converter for Lora weights not found for {cls_name}")
+
+            lora_state_dict = converter(state_dict)
+
+        if has_connector:
+            connector_state_dict = converter(state_dict, "text_embedding_projection")
+            lora_state_dict.update(connector_state_dict)
+
+        transformer_sd = {k: v for k, v in lora_state_dict.items() if k.startswith(self.transformer_name)}
+        connectors_sd = {k: v for k, v in lora_state_dict.items() if k.startswith(self.connectors_name)}
+
+        transformer = get_transformer_from_pipeline(self)
+        lora_deltas = self.load_lora_into_module(
+            transformer_sd,
+            transformer,
+            prefix=self.transformer_name,
+        )
+
+        connectors = find_module_with_attr(self, self.connectors_name).connectors
+        if connectors_sd:
+            lora_deltas.update(
+                self.load_lora_into_module(
+                    connectors_sd,
+                    connectors,
+                    prefix=self.connectors_name,
+                )
+            )
+
+        self.lora_loaded_deltas[adapter_name] = lora_deltas
+
+    def unload_lora_weights(self, adapter_name: str):
+        if adapter_name not in self.lora_loaded:
+            return
+        lora_deltas = self.lora_loaded_deltas[adapter_name]
+
+        transformer = get_transformer_from_pipeline(self)
+        self.unload_module_lora(transformer, lora_deltas, prefix=self.transformer_name)
+
+        connectors = find_module_with_attr(self, self.connectors_name).connectors
+        self.unload_module_lora(connectors, lora_deltas, prefix=self.connectors_name)
+
+        self.lora_loaded.remove(adapter_name)
+        del self.lora_loaded_deltas[adapter_name]
+
+    @classmethod
+    def load_lora_into_module(
+        cls,
+        state_dict,
+        module,
+        prefix: str = "transformer",
+    ):
+        lora_deltas = {}
+        lora_a_suffix = "lora_A.weight"
+        lora_b_suffix = "lora_B.weight"
+
+        # handle stacked QKV fusion
+        stacked_sd = defaultdict(list)
+        for key, param in state_dict.items():
+            base_key = key[: -len(f".{lora_a_suffix}")]
+            is_stacked_param = False
+            if hasattr(module, "stacked_params_mapping"):
+                # attn1.to_q.lora_A.weight
+                #                           => attn1.to_q => attn1.to_q.delta
+                # attn1.to_q.lora_B.weight
+                for param_name, weight_name, _ in module.stacked_params_mapping:
+                    if weight_name not in key:
+                        continue
+                    is_stacked_param = True
+                    if key.endswith(lora_a_suffix):
+                        a = param
+                        b = state_dict[f"{base_key}.{lora_b_suffix}"]
+                        delta = torch.matmul(b, a)
+                        stacked_base_key = key.replace(weight_name, param_name)[: -len(f".{lora_a_suffix}")]
+                        stacked_sd[stacked_base_key].append(delta)
+
+                if is_stacked_param:
+                    continue
+
+                if key.endswith(lora_a_suffix):
+                    a = param
+                    b = state_dict[f"{base_key}.{lora_b_suffix}"]
+                    delta = torch.matmul(b, a)
+                    lora_deltas[base_key] = delta
+            else:
+                if key.endswith(lora_a_suffix):
+                    a = param
+                    b = state_dict[f"{base_key}.{lora_b_suffix}"]
+                    delta = torch.matmul(b, a)
+                    lora_deltas[base_key] = delta
+
+        for stacked_base_key, delta_list in stacked_sd.items():
+            stacked_delta = torch.concat(delta_list)
+            lora_deltas[stacked_base_key] = stacked_delta
+
+        lora_loaded_keys = set()
+        lora_key_loaded_count = 0
+        for name, params in module.named_parameters(prefix):
+            if not name.endswith(".weight"):
+                continue
+
+            base_key = name[: -len(".weight")]
+            lora_a_key = f"{base_key}.{lora_a_suffix}"
+            lora_b_key = f"{base_key}.{lora_b_suffix}"
+
+            if base_key not in lora_deltas:
+                continue
+
+            delta = lora_deltas[base_key].to(device=params.device, dtype=params.dtype)
+            params.add_(delta)
+            lora_key_loaded_count += 1
+            del delta
+
+            is_stacked_param = False
+            if hasattr(module, "stacked_params_mapping"):
+                for param_name, weight_name, _ in module.stacked_params_mapping:
+                    if param_name not in base_key:
+                        continue
+                    is_stacked_param = True
+                    lora_a_key = f"{base_key.replace(param_name, weight_name)}.{lora_a_suffix}"
+                    lora_b_key = f"{base_key.replace(param_name, weight_name)}.{lora_b_suffix}"
+
+                    if lora_a_key in state_dict:
+                        lora_loaded_keys.add(lora_a_key)
+                    else:
+                        logger.warning(f"Failed to index lora key {lora_a_key}")
+                    if lora_b_key in state_dict:
+                        lora_loaded_keys.add(lora_b_key)
+                    else:
+                        logger.warning(f"Failed to index lora key {lora_b_key}")
+
+                if not is_stacked_param:
+                    lora_loaded_keys.add(lora_a_key)
+                    lora_loaded_keys.add(lora_b_key)
+            else:
+                lora_loaded_keys.add(lora_a_key)
+                lora_loaded_keys.add(lora_b_key)
+
+        for k in state_dict:
+            if k not in lora_loaded_keys:
+                logger.warning(f"Missing loading lora key: {k}")
+
+        logger.info(f"{lora_key_loaded_count} lora keys loaded into {module.__class__.__name__}.")
+
+        return lora_deltas
+
+    def unload_module_lora(
+        self,
+        module,
+        lora_deltas,
+        prefix: str = "transformer",
+    ):
+        lora_key_unload_count = 0
+        for name, param in module.named_parameters(prefix):
+            if not name.endswith(".weight"):
+                continue
+
+            base_key = name[: -len(".weight")]
+            if base_key not in lora_deltas:
+                continue
+
+            delta = lora_deltas[base_key].to(device=param.device, dtype=param.dtype)
+            param.sub_(delta)
+            lora_key_unload_count += 1
+
+        logger.info(f"Unload {lora_key_unload_count} lora keys from {module.__class__.__name__}.")

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -173,14 +173,45 @@ class LoraLoaderMixin:
         lora_deltas = _prepare_lora_deltas(state_dict, module, lora_a_suffix, lora_b_suffix)
         lora_loaded_keys = set()
         lora_key_loaded_count = 0
+
+        param_to_weight_names = defaultdict(list)
+        if hasattr(module, "stacked_params_mapping"):
+            for param_name, weight_name, _ in module.stacked_params_mapping:
+                param_to_weight_names[param_name].append(weight_name)
+
+        def update_loaded_keys(base_key):
+            """
+            This function updates lora_loaded_keys. It must be called after the parameter
+            of base_key is merged into module.
+            """
+            lora_a_key = f"{base_key}.{lora_a_suffix}"
+            lora_b_key = f"{base_key}.{lora_b_suffix}"
+
+            is_stacked_param = False
+            for param_name, weight_names in param_to_weight_names.items():
+                if param_name not in base_key:
+                    continue
+                is_stacked_param = True
+                for weight_name in weight_names:
+                    lora_a_key = f"{base_key.replace(param_name, weight_name)}.{lora_a_suffix}"
+                    lora_b_key = f"{base_key.replace(param_name, weight_name)}.{lora_b_suffix}"
+                    for k in (lora_a_key, lora_b_key):
+                        if k in state_dict:
+                            lora_loaded_keys.add(k)
+                        else:
+                            logger.warning(f"Failed to index lora key {k}")
+                break
+
+            if not is_stacked_param:
+                # sanity check is no need, as lora_deltas already checked
+                lora_loaded_keys.add(lora_a_key)
+                lora_loaded_keys.add(lora_b_key)
+
         for name, params in module.named_parameters(prefix):
             if not name.endswith(".weight"):
                 continue
 
             base_key = name[: -len(".weight")]
-            lora_a_key = f"{base_key}.{lora_a_suffix}"
-            lora_b_key = f"{base_key}.{lora_b_suffix}"
-
             if base_key not in lora_deltas:
                 continue
 
@@ -189,30 +220,7 @@ class LoraLoaderMixin:
             lora_key_loaded_count += 1
             del delta
 
-            is_stacked_param = False
-            if hasattr(module, "stacked_params_mapping"):
-                for param_name, weight_name, _ in module.stacked_params_mapping:
-                    if param_name not in base_key:
-                        continue
-                    is_stacked_param = True
-                    lora_a_key = f"{base_key.replace(param_name, weight_name)}.{lora_a_suffix}"
-                    lora_b_key = f"{base_key.replace(param_name, weight_name)}.{lora_b_suffix}"
-
-                    if lora_a_key in state_dict:
-                        lora_loaded_keys.add(lora_a_key)
-                    else:
-                        logger.warning(f"Failed to index lora key {lora_a_key}")
-                    if lora_b_key in state_dict:
-                        lora_loaded_keys.add(lora_b_key)
-                    else:
-                        logger.warning(f"Failed to index lora key {lora_b_key}")
-
-                if not is_stacked_param:
-                    lora_loaded_keys.add(lora_a_key)
-                    lora_loaded_keys.add(lora_b_key)
-            else:
-                lora_loaded_keys.add(lora_a_key)
-                lora_loaded_keys.add(lora_b_key)
+            update_loaded_keys(base_key)
 
         for k in state_dict:
             if k not in lora_loaded_keys:

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -211,10 +211,20 @@ class LoraLoaderMixin:
                 lora_loaded_keys.add(lora_b_key)
 
         for name, params in module.named_parameters(prefix):
-            if not name.endswith(".weight"):
+            if name.endswith(".weight"):
+                base_key = name[: -len(".weight")]
+            elif name.endswith(".bias"):
+                base_key = name[: -len(".bias")]
+                diff_bias_key = f"{base_key}.diff_b" if name not in state_dict else name
+                if diff_bias_key not in state_dict:
+                    continue
+                bias = state_dict[diff_bias_key]
+                params.add_(bias)
+                lora_key_loaded_count += 1
+                continue
+            else:
                 continue
 
-            base_key = name[: -len(".weight")]
             if base_key not in lora_deltas:
                 continue
 

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -286,7 +286,7 @@ class LoraLoaderMixin:
 
         num_unloaded_keys = 0
         for k in lora_unloaded_keys:
-            if k not in lora_unloaded_keys:
+            if k not in state_dict:
                 logger.warning(f"Missing unloading lora key: {k}")
             else:
                 num_unloaded_keys += 1
@@ -330,13 +330,15 @@ class QwenImageLoraLoaderMixin(LoraLoaderMixin):
         if adapter_name not in self.lora_loaded:
             return
 
+        state_dict = self.lora_loaded[adapter_name]
+
         transformer = get_transformer_from_pipeline(self)
-        self.unload_module_lora(transformer, prefix=self.transformer_name)
+        self.unload_module_lora(state_dict, transformer, prefix=self.transformer_name)
 
         del self.lora_loaded[adapter_name]
 
 
-class LTX2LoraLoaderMinxin(LoraLoaderMixin):
+class LTX2LoraLoaderMixin(LoraLoaderMixin):
     connectors_name = "connectors"
     lora_loaded = dict()
 

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -1,10 +1,11 @@
 import os
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from collections.abc import Callable
 
 import torch
 from diffusers.loaders.lora_conversion_utils import (
     _convert_non_diffusers_ltx2_lora_to_diffusers,
+    _convert_non_diffusers_qwen_lora_to_diffusers,
 )
 from huggingface_hub import hf_hub_download
 from safetensors.torch import load_file
@@ -14,10 +15,18 @@ from vllm_omni.diffusion.utils.tf_utils import find_module_with_attr, get_transf
 
 logger = init_logger(__name__)
 
+LORA_DIFFUSERS_CONVERTER_REGISTRY = {}
 
 lora_convert_mapping: dict[str, Callable] = {
     "LTX2Pipeline": _convert_non_diffusers_ltx2_lora_to_diffusers,
+    "QwenImagePipeline": _convert_non_diffusers_qwen_lora_to_diffusers,
+    "QwenImageEditPipeline": _convert_non_diffusers_qwen_lora_to_diffusers,
+    "QwenImageEditPlusPipeline": _convert_non_diffusers_qwen_lora_to_diffusers,
 }
+
+
+def get_converter_by_pipeline(pipeline):
+    return lora_convert_mapping.get(pipeline.__class__.__name__, None)
 
 
 def _load_lora_state_dict(
@@ -58,6 +67,209 @@ def _load_lora_state_dict(
         raise e
 
 
+def _remap_state_dict_keys(sd, rules):
+    """
+    Remap keys in a state_dict based on a priority list of substring substitution rules.
+
+    This utility function transforms parameter names by applying a sequence of
+    (old_substring, new_substring) pairs.
+
+    For each key in the input dictionary, the `rules` are evaluated in the given order.
+    The **first** rule whose `old_substring` is found within the key triggers a
+    replacement. Once a match occurs, the search stops and no further rules are
+    considered for that key. Keys that do not match any rule are copied unchanged.
+
+    Args:
+        sd (dict[str, Any]): Original state_dict mapping parameter names to tensors.
+        rules (List[Tuple[str, str]]): A list of (old_substring, new_substring) pairs.
+            Rules are applied sequentially with first-match precedence.
+
+    Returns:
+        dict[str, Any]: A new state_dict with remapped keys. Values are unchanged.
+    """
+    new_sd = OrderedDict()
+    for k, v in sd.items():
+        matched = False
+        for p1, p2 in rules:
+            if p1 not in k:
+                continue
+            new_sd[k.replace(p1, p2)] = v
+            matched = True
+            break
+        if not matched:
+            new_sd[k] = v
+    return new_sd
+
+
+class QwenImageLoraLoaderMixin:
+    transformer_name = "transformer"
+    lora_loaded = set()
+    lora_loaded_deltas = {}
+
+    def load_lora_weights(
+        self,
+        pretrained_model_name_or_path: str,
+        adapter_name: str | None = None,
+    ):
+        if adapter_name in self.lora_loaded:
+            return
+        self.lora_loaded.add(adapter_name)
+
+        state_dict = _load_lora_state_dict(pretrained_model_name_or_path)
+
+        has_alpha = any(k.endswith(".alpha") for k in state_dict)
+        is_non_diffusers_format = any(k.startswith("diffusion_model.") for k in state_dict)
+        if has_alpha or is_non_diffusers_format:
+            converter = get_converter_by_pipeline(self)
+            if converter is None:
+                raise ValueError(f"Converter for Lora weights not found for {self.__class__.__name__}")
+
+            state_dict = converter(state_dict)
+
+        state_dict = _remap_state_dict_keys(state_dict, [(".to_out.0.", ".to_out.")])
+
+        lora_deltas = self.load_lora_into_module(
+            state_dict,
+            self.transformer,
+            prefix=self.transformer_name,
+        )
+
+        self.lora_loaded_deltas[adapter_name] = lora_deltas
+
+    def unload_lora_weights(self, adapter_name: str):
+        if adapter_name not in self.lora_loaded:
+            return
+        lora_deltas = self.lora_loaded_deltas[adapter_name]
+
+        transformer = get_transformer_from_pipeline(self)
+        self.unload_module_lora(transformer, lora_deltas, prefix=self.transformer_name)
+
+        self.lora_loaded.remove(adapter_name)
+        del self.lora_loaded_deltas[adapter_name]
+
+    @classmethod
+    def load_lora_into_module(
+        cls,
+        state_dict,
+        module,
+        prefix: str = "transformer",
+    ):
+        lora_deltas = {}
+        lora_a_suffix = "lora_A.weight"
+        lora_b_suffix = "lora_B.weight"
+
+        # handle stacked QKV fusion
+        stacked_sd = defaultdict(list)
+        for key, param in state_dict.items():
+            base_key = key[: -len(f".{lora_a_suffix}")]
+            is_stacked_param = False
+            if hasattr(module, "stacked_params_mapping"):
+                # attn1.to_q.lora_A.weight
+                #                           => attn1.to_q => attn1.to_q.delta
+                # attn1.to_q.lora_B.weight
+                for param_name, weight_name, _ in module.stacked_params_mapping:
+                    if weight_name not in key:
+                        continue
+                    is_stacked_param = True
+                    if key.endswith(lora_a_suffix):
+                        a = param
+                        b = state_dict[f"{base_key}.{lora_b_suffix}"]
+                        delta = torch.matmul(b, a)
+                        stacked_base_key = key.replace(weight_name, param_name)[: -len(f".{lora_a_suffix}")]
+                        stacked_sd[stacked_base_key].append(delta)
+
+                if is_stacked_param:
+                    continue
+
+                if key.endswith(lora_a_suffix):
+                    a = param
+                    b = state_dict[f"{base_key}.{lora_b_suffix}"]
+                    delta = torch.matmul(b, a)
+                    lora_deltas[base_key] = delta
+            else:
+                if key.endswith(lora_a_suffix):
+                    a = param
+                    b = state_dict[f"{base_key}.{lora_b_suffix}"]
+                    delta = torch.matmul(b, a)
+                    lora_deltas[base_key] = delta
+
+        for stacked_base_key, delta_list in stacked_sd.items():
+            stacked_delta = torch.concat(delta_list)
+            lora_deltas[stacked_base_key] = stacked_delta
+
+        lora_loaded_keys = set()
+        lora_key_loaded_count = 0
+        for name, params in module.named_parameters(prefix):
+            if not name.endswith(".weight"):
+                continue
+
+            base_key = name[: -len(".weight")]
+            lora_a_key = f"{base_key}.{lora_a_suffix}"
+            lora_b_key = f"{base_key}.{lora_b_suffix}"
+
+            if base_key not in lora_deltas:
+                continue
+
+            delta = lora_deltas[base_key].to(device=params.device, dtype=params.dtype)
+            params.add_(delta)
+            lora_key_loaded_count += 1
+            del delta
+
+            is_stacked_param = False
+            if hasattr(module, "stacked_params_mapping"):
+                for param_name, weight_name, _ in module.stacked_params_mapping:
+                    if param_name not in base_key:
+                        continue
+                    is_stacked_param = True
+                    lora_a_key = f"{base_key.replace(param_name, weight_name)}.{lora_a_suffix}"
+                    lora_b_key = f"{base_key.replace(param_name, weight_name)}.{lora_b_suffix}"
+
+                    if lora_a_key in state_dict:
+                        lora_loaded_keys.add(lora_a_key)
+                    else:
+                        logger.warning(f"Failed to index lora key {lora_a_key}")
+                    if lora_b_key in state_dict:
+                        lora_loaded_keys.add(lora_b_key)
+                    else:
+                        logger.warning(f"Failed to index lora key {lora_b_key}")
+
+                if not is_stacked_param:
+                    lora_loaded_keys.add(lora_a_key)
+                    lora_loaded_keys.add(lora_b_key)
+            else:
+                lora_loaded_keys.add(lora_a_key)
+                lora_loaded_keys.add(lora_b_key)
+
+        for k in state_dict:
+            if k not in lora_loaded_keys:
+                logger.warning(f"Missing loading lora key: {k}")
+
+        logger.info(f"{lora_key_loaded_count} lora keys loaded into {module.__class__.__name__}.")
+
+        return lora_deltas
+
+    def unload_module_lora(
+        self,
+        module,
+        lora_deltas,
+        prefix: str = "transformer",
+    ):
+        lora_key_unload_count = 0
+        for name, param in module.named_parameters(prefix):
+            if not name.endswith(".weight"):
+                continue
+
+            base_key = name[: -len(".weight")]
+            if base_key not in lora_deltas:
+                continue
+
+            delta = lora_deltas[base_key].to(device=param.device, dtype=param.dtype)
+            param.sub_(delta)
+            lora_key_unload_count += 1
+
+        logger.info(f"Unload {lora_key_unload_count} lora keys from {module.__class__.__name__}.")
+
+
 class LTX2LoraLoaderMinxin:
     transformer_name = "transformer"
     connectors_name = "connectors"
@@ -81,10 +293,9 @@ class LTX2LoraLoaderMinxin:
         has_connector = any(k.startswith("text_embedding_projection.") for k in state_dict)
 
         if is_non_diffusers_format:
-            cls_name = self.__class__.__name__
-            converter = lora_convert_mapping.get(cls_name, None)
+            converter = get_converter_by_pipeline(self)
             if converter is None:
-                raise ValueError(f"Converter for Lora weights not found for {cls_name}")
+                raise ValueError(f"Converter for Lora weights not found for {self.__class__.__name__}")
 
             lora_state_dict = converter(state_dict)
 

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -424,6 +424,7 @@ class WanLoraLoaderMixin(LoraLoaderMixin):
 
         cls_name = self.__class__.__name__
         task = "i2v" if "I2V" in cls_name else "t2v"
+        module_to_lora_sd = dict()
 
         lora_paths = self._get_target_lora_paths(pretrained_model_name_or_path, self.has_transformer_2, task=task)
         for lora_path in lora_paths:
@@ -457,19 +458,22 @@ class WanLoraLoaderMixin(LoraLoaderMixin):
                 target_module_name = self.supported_ckpt_mapping[filename]
                 module = getattr(find_module_with_attr(self, target_module_name), target_module_name)
                 self.load_lora_into_module(state_dict, module, prefix=self.transformer_name, lora_bias_suffix="bias")
+                module_to_lora_sd[target_module_name] = state_dict
             else:
                 # wan21 load path
                 self.load_lora_into_module(state_dict, self.transformer, prefix=self.transformer_name)
+                module_to_lora_sd[self.transformer_name] = state_dict
 
-            self.lora_loaded[adapter_name] = state_dict
+        self.lora_loaded[adapter_name] = module_to_lora_sd
 
     def unload_lora_weights(self, adapter_name: str):
         if adapter_name not in self.lora_loaded:
             return
-        state_dict = self.lora_loaded[adapter_name]
 
-        transformer = get_transformer_from_pipeline(self)
-        self.unload_module_lora(state_dict, transformer, prefix=self.transformer_name)
+        module_to_lora_sd = self.lora_loaded[adapter_name]
+        for module_name, lora_sd in module_to_lora_sd.items():
+            module = getattr(find_module_with_attr(self, module_name), module_name)
+            self.unload_module_lora(lora_sd, module, prefix=self.transformer_name)
 
         del self.lora_loaded[adapter_name]
 

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -254,10 +254,6 @@ class LoraLoaderMixin:
 
 
 class QwenImageLoraLoaderMixin(LoraLoaderMixin):
-    transformer_name = "transformer"
-    lora_loaded = set()
-    lora_loaded_deltas = {}
-
     def load_lora_weights(
         self,
         pretrained_model_name_or_path: str,
@@ -301,11 +297,7 @@ class QwenImageLoraLoaderMixin(LoraLoaderMixin):
 
 
 class LTX2LoraLoaderMinxin(LoraLoaderMixin):
-    transformer_name = "transformer"
     connectors_name = "connectors"
-
-    lora_loaded = set()
-    lora_loaded_deltas = {}
 
     def load_lora_weights(
         self,

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -58,7 +58,7 @@ def _load_lora_state_dict(
         raise e
 
 
-class LTX2LoRALoaderMinxin:
+class LTX2LoraLoaderMinxin:
     transformer_name = "transformer"
     connectors_name = "connectors"
 

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -29,6 +29,50 @@ def get_converter_by_pipeline(pipeline):
     return lora_convert_mapping.get(pipeline.__class__.__name__, None)
 
 
+def _prepare_lora_deltas(lora_sd, module, lora_a_suffix="lora_A.weight", lora_b_suffix="lora_B.weight"):
+    lora_deltas = {}
+
+    stacked_sd = defaultdict(list)
+    for key, param in lora_sd.items():
+        base_key = key[: -len(f".{lora_a_suffix}")]
+        is_stacked_param = False
+        if hasattr(module, "stacked_params_mapping"):
+            # attn1.to_q.lora_A.weight
+            #                           => attn1.to_q => attn1.to_q.delta
+            # attn1.to_q.lora_B.weight
+            for param_name, weight_name, _ in module.stacked_params_mapping:
+                if weight_name not in key:
+                    continue
+                is_stacked_param = True
+                if key.endswith(lora_a_suffix):
+                    a = param
+                    b = lora_sd[f"{base_key}.{lora_b_suffix}"]
+                    delta = torch.matmul(b, a)
+                    stacked_base_key = key.replace(weight_name, param_name)[: -len(f".{lora_a_suffix}")]
+                    stacked_sd[stacked_base_key].append(delta)
+
+            if is_stacked_param:
+                continue
+
+            if key.endswith(lora_a_suffix):
+                a = param
+                b = lora_sd[f"{base_key}.{lora_b_suffix}"]
+                delta = torch.matmul(b, a)
+                lora_deltas[base_key] = delta
+        else:
+            if key.endswith(lora_a_suffix):
+                a = param
+                b = lora_sd[f"{base_key}.{lora_b_suffix}"]
+                delta = torch.matmul(b, a)
+                lora_deltas[base_key] = delta
+
+    for stacked_base_key, delta_list in stacked_sd.items():
+        stacked_delta = torch.concat(delta_list)
+        lora_deltas[stacked_base_key] = stacked_delta
+
+    return lora_deltas
+
+
 def _load_lora_state_dict(
     pretrained_model_name_or_path: str,
     weights_name: str | None = None,
@@ -112,50 +156,10 @@ class LoraLoaderMixin:
         state_dict,
         module,
         prefix: str = "transformer",
+        lora_a_suffix: str = "lora_A.weight",
+        lora_b_suffix: str = "lora_B.weight",
     ):
-        lora_deltas = {}
-        lora_a_suffix = "lora_A.weight"
-        lora_b_suffix = "lora_B.weight"
-
-        # handle stacked QKV fusion
-        stacked_sd = defaultdict(list)
-        for key, param in state_dict.items():
-            base_key = key[: -len(f".{lora_a_suffix}")]
-            is_stacked_param = False
-            if hasattr(module, "stacked_params_mapping"):
-                # attn1.to_q.lora_A.weight
-                #                           => attn1.to_q => attn1.to_q.delta
-                # attn1.to_q.lora_B.weight
-                for param_name, weight_name, _ in module.stacked_params_mapping:
-                    if weight_name not in key:
-                        continue
-                    is_stacked_param = True
-                    if key.endswith(lora_a_suffix):
-                        a = param
-                        b = state_dict[f"{base_key}.{lora_b_suffix}"]
-                        delta = torch.matmul(b, a)
-                        stacked_base_key = key.replace(weight_name, param_name)[: -len(f".{lora_a_suffix}")]
-                        stacked_sd[stacked_base_key].append(delta)
-
-                if is_stacked_param:
-                    continue
-
-                if key.endswith(lora_a_suffix):
-                    a = param
-                    b = state_dict[f"{base_key}.{lora_b_suffix}"]
-                    delta = torch.matmul(b, a)
-                    lora_deltas[base_key] = delta
-            else:
-                if key.endswith(lora_a_suffix):
-                    a = param
-                    b = state_dict[f"{base_key}.{lora_b_suffix}"]
-                    delta = torch.matmul(b, a)
-                    lora_deltas[base_key] = delta
-
-        for stacked_base_key, delta_list in stacked_sd.items():
-            stacked_delta = torch.concat(delta_list)
-            lora_deltas[stacked_base_key] = stacked_delta
-
+        lora_deltas = _prepare_lora_deltas(state_dict, module, lora_a_suffix, lora_b_suffix)
         lora_loaded_keys = set()
         lora_key_loaded_count = 0
         for name, params in module.named_parameters(prefix):

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -32,39 +32,50 @@ def get_converter_by_pipeline(pipeline):
 def _prepare_lora_deltas(lora_sd, module, lora_a_suffix="lora_A.weight", lora_b_suffix="lora_B.weight"):
     lora_deltas = {}
 
+    # prepare stacked parameters mapping for later use
+    # stacked_params_mapping                       param_to_weight_names
+    # [(".to_qkv", ".to_q.", "q")
+    # (".to_qkv", ".to_k.", "k")  ========> {".to_qkv": [".to_q", ".to_k", ".to_v"]}
+    # (".to_qkv", ".to_v.", "v")]
+
+    weight_to_param_name = {}
+    if hasattr(module, "stacked_params_mapping"):
+        weight_to_param_name = {weight_name: param_name for param_name, weight_name, _ in module.stacked_params_mapping}
+
+    # stacked_sd is to store packed parameter deltas (format: [str, list[torch.Tensor]])
+    # example: {".to_qkv": [delta_q, delta_k, delta_v]}
     stacked_sd = defaultdict(list)
     for key, param in lora_sd.items():
         base_key = key[: -len(f".{lora_a_suffix}")]
-        is_stacked_param = False
-        if hasattr(module, "stacked_params_mapping"):
-            # attn1.to_q.lora_A.weight
-            #                           => attn1.to_q => attn1.to_q.delta
-            # attn1.to_q.lora_B.weight
-            for param_name, weight_name, _ in module.stacked_params_mapping:
-                if weight_name not in key:
-                    continue
-                is_stacked_param = True
-                if key.endswith(lora_a_suffix):
-                    a = param
-                    b = lora_sd[f"{base_key}.{lora_b_suffix}"]
-                    delta = torch.matmul(b, a)
-                    stacked_base_key = key.replace(weight_name, param_name)[: -len(f".{lora_a_suffix}")]
-                    stacked_sd[stacked_base_key].append(delta)
 
-            if is_stacked_param:
+        is_stacked_param = False
+        for weight_name, param_name in weight_to_param_name.items():
+            if weight_name not in key:
+                continue
+            is_stacked_param = True
+            # handle lora_a_key and lora_b_key together
+            if key.endswith(lora_a_suffix):
+                a = param
+                b = lora_sd[f"{base_key}.{lora_b_suffix}"]
+                delta = torch.matmul(b, a)
+                stacked_base_key = key.replace(weight_name, param_name)[: -len(f".{lora_a_suffix}")]
+                stacked_sd[stacked_base_key].append(delta)
+            else:
+                # lora_b_key was already handled, skip
                 continue
 
-            if key.endswith(lora_a_suffix):
-                a = param
-                b = lora_sd[f"{base_key}.{lora_b_suffix}"]
-                delta = torch.matmul(b, a)
-                lora_deltas[base_key] = delta
+        if is_stacked_param:
+            # already handled, skip
+            continue
+
+        if key.endswith(lora_a_suffix):
+            a = param
+            b = lora_sd[f"{base_key}.{lora_b_suffix}"]
+            delta = torch.matmul(b, a)
+            lora_deltas[base_key] = delta
         else:
-            if key.endswith(lora_a_suffix):
-                a = param
-                b = lora_sd[f"{base_key}.{lora_b_suffix}"]
-                delta = torch.matmul(b, a)
-                lora_deltas[base_key] = delta
+            # same as above
+            continue
 
     for stacked_base_key, delta_list in stacked_sd.items():
         stacked_delta = torch.concat(delta_list)

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -32,59 +32,71 @@ def get_converter_by_pipeline(pipeline):
     return lora_convert_mapping.get(pipeline.__class__.__name__, None)
 
 
-def _prepare_lora_deltas(lora_sd, module, lora_a_suffix="lora_A.weight", lora_b_suffix="lora_B.weight"):
-    lora_deltas = {}
-
-    # prepare stacked parameters mapping for later use
+def _prepare_lora_deltas(
+    lora_sd,
+    base_key: str,
+    param_to_weight_names: dict[str, list[str]],
+    lora_matched_keys: set[str],
+    is_bias: bool = False,
+    lora_a_suffix: str = "lora_A.weight",
+    lora_b_suffix: str = "lora_B.weight",
+    lora_bias_suffix: str = ".bias",
+):
     # stacked_params_mapping                       param_to_weight_names
     # [(".to_qkv", ".to_q.", "q")
     # (".to_qkv", ".to_k.", "k")  ========> {".to_qkv": [".to_q", ".to_k", ".to_v"]}
     # (".to_qkv", ".to_v.", "v")]
 
-    weight_to_param_name = {}
-    if hasattr(module, "stacked_params_mapping"):
-        weight_to_param_name = {weight_name: param_name for param_name, weight_name, _ in module.stacked_params_mapping}
-
     # stacked_sd is to store packed parameter deltas (format: [str, list[torch.Tensor]])
     # example: {".to_qkv": [delta_q, delta_k, delta_v]}
-    stacked_sd = defaultdict(list)
-    for key, param in lora_sd.items():
-        base_key = key[: -len(f".{lora_a_suffix}")]
-
-        is_stacked_param = False
-        for weight_name, param_name in weight_to_param_name.items():
-            if weight_name not in key:
-                continue
-            is_stacked_param = True
-            # handle lora_a_key and lora_b_key together
-            if key.endswith(lora_a_suffix):
-                a = param
-                b = lora_sd[f"{base_key}.{lora_b_suffix}"]
-                delta = torch.matmul(b, a)
-                stacked_base_key = key.replace(weight_name, param_name)[: -len(f".{lora_a_suffix}")]
-                stacked_sd[stacked_base_key].append(delta)
-            else:
-                # lora_b_key was already handled, skip
-                continue
-
-        if is_stacked_param:
-            # already handled, skip
+    stacked_deltas = []
+    is_stacked_param = False
+    for param_name, weight_names in param_to_weight_names.items():
+        if param_name not in base_key:
             continue
-
-        if key.endswith(lora_a_suffix):
-            a = param
-            b = lora_sd[f"{base_key}.{lora_b_suffix}"]
-            delta = torch.matmul(b, a)
-            lora_deltas[base_key] = delta
+        is_stacked_param = True
+        # handle lora_a_key and lora_b_key together
+        if is_bias:
+            for weight_name in weight_names:
+                lora_bias_key = f"{base_key.replace(param_name, weight_name)}.{lora_bias_suffix}"
+                if lora_bias_key not in lora_sd:
+                    return None
+                delta = lora_sd[lora_bias_key]
+                stacked_deltas.append(delta)
+                lora_matched_keys.add(lora_bias_key)
         else:
-            # same as above
-            continue
+            for weight_name in weight_names:
+                lora_a_key = f"{base_key.replace(param_name, weight_name)}.{lora_a_suffix}"
+                lora_b_key = lora_a_key.replace(lora_a_suffix, lora_b_suffix)
+                if lora_a_key not in lora_sd or lora_b_key not in lora_sd:
+                    return None
+                a = lora_sd[lora_a_key]
+                b = lora_sd[lora_b_key]
+                delta = torch.matmul(b, a)
+                stacked_deltas.append(delta)
+                lora_matched_keys.add(lora_a_key)
+                lora_matched_keys.add(lora_b_key)
+        continue
 
-    for stacked_base_key, delta_list in stacked_sd.items():
-        stacked_delta = torch.concat(delta_list)
-        lora_deltas[stacked_base_key] = stacked_delta
+    if is_stacked_param:
+        return torch.concat(stacked_deltas)
 
-    return lora_deltas
+    if is_bias:
+        lora_bias_key = f"{base_key}.{lora_bias_suffix}"
+        if lora_bias_key not in lora_sd:
+            return None
+        lora_matched_keys.add(lora_bias_key)
+        return lora_sd[lora_bias_key]
+
+    lora_a_key = f"{base_key}.{lora_a_suffix}"
+    lora_b_key = f"{base_key}.{lora_b_suffix}"
+    if lora_a_key not in lora_sd or lora_b_key not in lora_sd:
+        return None
+    a = lora_sd[lora_a_key]
+    b = lora_sd[lora_b_key]
+    lora_matched_keys.add(lora_a_key)
+    lora_matched_keys.add(lora_b_key)
+    return torch.matmul(b, a)
 
 
 def _load_lora_state_dict(
@@ -161,8 +173,7 @@ def _remap_state_dict_keys(sd, rules):
 
 class LoraLoaderMixin:
     transformer_name = "transformer"
-    lora_loaded = set()
-    lora_loaded_deltas = {}
+    lora_loaded = dict()
 
     @classmethod
     def load_lora_into_module(
@@ -172,98 +183,111 @@ class LoraLoaderMixin:
         prefix: str = "transformer",
         lora_a_suffix: str = "lora_A.weight",
         lora_b_suffix: str = "lora_B.weight",
+        lora_bias_suffix: str = "bias",
     ):
-        lora_deltas = _prepare_lora_deltas(state_dict, module, lora_a_suffix, lora_b_suffix)
         lora_loaded_keys = set()
-        lora_key_loaded_count = 0
+
+        # prepare stacked parameters mapping for later use
+        # stacked_params_mapping                       param_to_weight_names
+        # [(".to_qkv", ".to_q.", "q")
+        # (".to_qkv", ".to_k.", "k")  ========> {".to_qkv": [".to_q", ".to_k", ".to_v"]}
+        # (".to_qkv", ".to_v.", "v")]
+        param_to_weight_names = defaultdict(list)
+        if hasattr(module, "stacked_params_mapping"):
+            for param_name, weight_name, _ in module.stacked_params_mapping:
+                param_to_weight_names[param_name].append(weight_name)
+
+        for name, params in module.named_parameters(prefix):
+            is_bias = False
+            if name.endswith(".bias"):
+                base_key = name[: -len(".bias")]
+                is_bias = True
+            elif name.endswith(".weight"):
+                base_key = name[: -len(".weight")]
+            else:
+                continue
+
+            delta = _prepare_lora_deltas(
+                state_dict,
+                base_key,
+                param_to_weight_names,
+                lora_loaded_keys,
+                is_bias,
+                lora_a_suffix,
+                lora_b_suffix,
+                lora_bias_suffix,
+            )
+            if delta is None:
+                continue
+
+            delta = delta.to(device=params.device, dtype=params.dtype)
+            with torch.no_grad():
+                params.add_(delta)
+            del delta
+
+        num_loaded_keys = 0
+        for k in state_dict:
+            if k not in lora_loaded_keys:
+                logger.warning(f"Missing loading lora key: {k}")
+            else:
+                num_loaded_keys += 1
+
+        assert num_loaded_keys == len(lora_loaded_keys)
+
+        logger.info(f"{num_loaded_keys} lora keys loaded into {module.__class__.__name__}.")
+
+    @classmethod
+    def unload_module_lora(
+        cls,
+        state_dict,
+        module,
+        prefix: str = "transformer",
+        lora_a_suffix: str = "lora_A.weight",
+        lora_b_suffix: str = "lora_B.weight",
+        lora_bias_suffix: str = "bias",
+    ):
+        lora_unloaded_keys = set()
 
         param_to_weight_names = defaultdict(list)
         if hasattr(module, "stacked_params_mapping"):
             for param_name, weight_name, _ in module.stacked_params_mapping:
                 param_to_weight_names[param_name].append(weight_name)
 
-        def update_loaded_keys(base_key):
-            """
-            This function updates lora_loaded_keys. It must be called after the parameter
-            of base_key is merged into module.
-            """
-            lora_a_key = f"{base_key}.{lora_a_suffix}"
-            lora_b_key = f"{base_key}.{lora_b_suffix}"
-
-            is_stacked_param = False
-            for param_name, weight_names in param_to_weight_names.items():
-                if param_name not in base_key:
-                    continue
-                is_stacked_param = True
-                for weight_name in weight_names:
-                    lora_a_key = f"{base_key.replace(param_name, weight_name)}.{lora_a_suffix}"
-                    lora_b_key = f"{base_key.replace(param_name, weight_name)}.{lora_b_suffix}"
-                    for k in (lora_a_key, lora_b_key):
-                        if k in state_dict:
-                            lora_loaded_keys.add(k)
-                        else:
-                            logger.warning(f"Failed to index lora key {k}")
-                break
-
-            if not is_stacked_param:
-                # sanity check is no need, as lora_deltas already checked
-                lora_loaded_keys.add(lora_a_key)
-                lora_loaded_keys.add(lora_b_key)
-
-        for name, params in module.named_parameters(prefix):
-            if name.endswith(".weight"):
-                base_key = name[: -len(".weight")]
-            elif name.endswith(".bias"):
+        for name, param in module.named_parameters(prefix):
+            is_bias = False
+            if name.endswith(".bias"):
                 base_key = name[: -len(".bias")]
-                diff_bias_key = f"{base_key}.diff_b" if name not in state_dict else name
-                if diff_bias_key not in state_dict:
-                    continue
-                bias = state_dict[diff_bias_key]
-                params.add_(bias)
-                lora_key_loaded_count += 1
-                continue
+                is_bias = True
+            elif name.endswith(".weight"):
+                base_key = name[: -len(".weight")]
             else:
                 continue
 
-            if base_key not in lora_deltas:
+            delta = _prepare_lora_deltas(
+                state_dict,
+                base_key,
+                param_to_weight_names,
+                lora_unloaded_keys,
+                is_bias,
+                lora_a_suffix,
+                lora_b_suffix,
+                lora_bias_suffix,
+            )
+            if delta is None:
                 continue
 
-            delta = lora_deltas[base_key].to(device=params.device, dtype=params.dtype)
-            params.add_(delta)
-            lora_key_loaded_count += 1
+            delta = delta.to(device=param.device, dtype=param.dtype)
+            param.sub_(delta)
             del delta
 
-            update_loaded_keys(base_key)
+        num_unloaded_keys = 0
+        for k in lora_unloaded_keys:
+            if k not in lora_unloaded_keys:
+                logger.warning(f"Missing unloading lora key: {k}")
+            else:
+                num_unloaded_keys += 1
 
-        for k in state_dict:
-            if k not in lora_loaded_keys:
-                logger.warning(f"Missing loading lora key: {k}")
-
-        logger.info(f"{lora_key_loaded_count} lora keys loaded into {module.__class__.__name__}.")
-
-        return lora_deltas
-
-    @classmethod
-    def unload_module_lora(
-        cls,
-        module,
-        lora_deltas,
-        prefix: str = "transformer",
-    ):
-        lora_key_unload_count = 0
-        for name, param in module.named_parameters(prefix):
-            if not name.endswith(".weight"):
-                continue
-
-            base_key = name[: -len(".weight")]
-            if base_key not in lora_deltas:
-                continue
-
-            delta = lora_deltas[base_key].to(device=param.device, dtype=param.dtype)
-            param.sub_(delta)
-            lora_key_unload_count += 1
-
-        logger.info(f"Unload {lora_key_unload_count} lora keys from {module.__class__.__name__}.")
+        logger.info(f"Unload {num_unloaded_keys} lora keys from {module.__class__.__name__}.")
 
 
 class QwenImageLoraLoaderMixin(LoraLoaderMixin):
@@ -274,7 +298,6 @@ class QwenImageLoraLoaderMixin(LoraLoaderMixin):
     ):
         if adapter_name in self.lora_loaded:
             return
-        self.lora_loaded.add(adapter_name)
 
         state_dict = _load_lora_state_dict(pretrained_model_name_or_path)
 
@@ -289,24 +312,22 @@ class QwenImageLoraLoaderMixin(LoraLoaderMixin):
 
         state_dict = _remap_state_dict_keys(state_dict, [(".to_out.0.", ".to_out.")])
 
-        lora_deltas = self.load_lora_into_module(
+        self.load_lora_into_module(
             state_dict,
             self.transformer,
             prefix=self.transformer_name,
         )
 
-        self.lora_loaded_deltas[adapter_name] = lora_deltas
+        self.lora_loaded[adapter_name] = state_dict
 
     def unload_lora_weights(self, adapter_name: str):
         if adapter_name not in self.lora_loaded:
             return
-        lora_deltas = self.lora_loaded_deltas[adapter_name]
 
         transformer = get_transformer_from_pipeline(self)
-        self.unload_module_lora(transformer, lora_deltas, prefix=self.transformer_name)
+        self.unload_module_lora(transformer, prefix=self.transformer_name)
 
-        self.lora_loaded.remove(adapter_name)
-        del self.lora_loaded_deltas[adapter_name]
+        del self.lora_loaded[adapter_name]
 
 
 class LTX2LoraLoaderMinxin(LoraLoaderMixin):
@@ -319,7 +340,6 @@ class LTX2LoraLoaderMinxin(LoraLoaderMixin):
     ):
         if adapter_name in self.lora_loaded:
             return
-        self.lora_loaded.add(adapter_name)
 
         state_dict = _load_lora_state_dict(pretrained_model_name_or_path)
 
@@ -342,7 +362,7 @@ class LTX2LoraLoaderMinxin(LoraLoaderMixin):
         connectors_sd = {k: v for k, v in lora_state_dict.items() if k.startswith(self.connectors_name)}
 
         transformer = get_transformer_from_pipeline(self)
-        lora_deltas = self.load_lora_into_module(
+        self.load_lora_into_module(
             transformer_sd,
             transformer,
             prefix=self.transformer_name,
@@ -350,29 +370,28 @@ class LTX2LoraLoaderMinxin(LoraLoaderMixin):
 
         connectors = find_module_with_attr(self, self.connectors_name).connectors
         if connectors_sd:
-            lora_deltas.update(
-                self.load_lora_into_module(
-                    connectors_sd,
-                    connectors,
-                    prefix=self.connectors_name,
-                )
+            self.load_lora_into_module(
+                connectors_sd,
+                connectors,
+                prefix=self.connectors_name,
             )
 
-        self.lora_loaded_deltas[adapter_name] = lora_deltas
+        self.lora_loaded[adapter_name] = lora_state_dict
 
     def unload_lora_weights(self, adapter_name: str):
         if adapter_name not in self.lora_loaded:
             return
-        lora_deltas = self.lora_loaded_deltas[adapter_name]
+        state_dict = self.lora_loaded[adapter_name]
+        transformer_sd = {k: v for k, v in state_dict.items() if k.startswith(self.transformer_name)}
+        connectors_sd = {k: v for k, v in state_dict.items() if k.startswith(self.connectors_name)}
 
         transformer = get_transformer_from_pipeline(self)
-        self.unload_module_lora(transformer, lora_deltas, prefix=self.transformer_name)
+        self.unload_module_lora(transformer_sd, transformer, prefix=self.transformer_name)
 
         connectors = find_module_with_attr(self, self.connectors_name).connectors
-        self.unload_module_lora(connectors, lora_deltas, prefix=self.connectors_name)
+        self.unload_module_lora(connectors_sd, connectors, prefix=self.connectors_name)
 
-        self.lora_loaded.remove(adapter_name)
-        del self.lora_loaded_deltas[adapter_name]
+        del self.lora_loaded[adapter_name]
 
 
 class WanLoraLoaderMixin(LoraLoaderMixin):
@@ -392,7 +411,6 @@ class WanLoraLoaderMixin(LoraLoaderMixin):
     ):
         if adapter_name in self.lora_loaded:
             return
-        self.lora_loaded.add(adapter_name)
 
         cls_name = self.__class__.__name__
         task = "i2v" if "I2V" in cls_name else "t2v"
@@ -417,6 +435,9 @@ class WanLoraLoaderMixin(LoraLoaderMixin):
                         ".to_out.0.",
                         ".to_out.",
                     ),
+                    # '.bias_B.bias' is a horrible name in diffuser's.
+                    # So we remap it to '.bias'
+                    (".lora_B.bias", ".bias"),
                 ],
             )
 
@@ -425,21 +446,22 @@ class WanLoraLoaderMixin(LoraLoaderMixin):
                 filename = os.path.basename(lora_path)
                 target_module_name = self.supported_ckpt_mapping[filename]
                 module = getattr(find_module_with_attr(self, target_module_name), target_module_name)
-                self.load_lora_into_module(state_dict, module, prefix=self.transformer_name)
+                self.load_lora_into_module(state_dict, module, prefix=self.transformer_name, lora_bias_suffix="bias")
             else:
                 # wan21 load path
                 self.load_lora_into_module(state_dict, self.transformer, prefix=self.transformer_name)
 
+            self.lora_loaded[adapter_name] = state_dict
+
     def unload_lora_weights(self, adapter_name: str):
         if adapter_name not in self.lora_loaded:
             return
-        lora_deltas = self.lora_loaded_deltas[adapter_name]
+        state_dict = self.lora_loaded[adapter_name]
 
         transformer = get_transformer_from_pipeline(self)
-        self.unload_module_lora(transformer, lora_deltas, prefix=self.transformer_name)
+        self.unload_module_lora(state_dict, transformer, prefix=self.transformer_name)
 
-        self.lora_loaded.remove(adapter_name)
-        del self.lora_loaded_deltas[adapter_name]
+        del self.lora_loaded[adapter_name]
 
     def _get_target_lora_paths(
         self,

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -178,7 +178,6 @@ def _remap_state_dict_keys(sd, rules):
 
 class LoraLoaderMixin:
     transformer_name = "transformer"
-    lora_loaded = dict()
 
     @classmethod
     def load_lora_into_module(
@@ -296,6 +295,8 @@ class LoraLoaderMixin:
 
 
 class QwenImageLoraLoaderMixin(LoraLoaderMixin):
+    lora_loaded = dict()
+
     def load_lora_weights(
         self,
         pretrained_model_name_or_path: str,
@@ -337,6 +338,7 @@ class QwenImageLoraLoaderMixin(LoraLoaderMixin):
 
 class LTX2LoraLoaderMinxin(LoraLoaderMixin):
     connectors_name = "connectors"
+    lora_loaded = dict()
 
     def load_lora_weights(
         self,
@@ -400,6 +402,7 @@ class LTX2LoraLoaderMinxin(LoraLoaderMixin):
 
 
 class WanLoraLoaderMixin(LoraLoaderMixin):
+    lora_loaded = dict()
     supported_ckpt_mapping = {
         "wan2.2_i2v_A14b_high_noise_lora_rank64_lightx2v_4step_1022.safetensors": "transformer",
         "wan2.2_i2v_A14b_low_noise_lora_rank64_lightx2v_4step_1022.safetensors": "transformer_2",

--- a/vllm_omni/diffusion/lora/loader.py
+++ b/vllm_omni/diffusion/lora/loader.py
@@ -139,34 +139,39 @@ def _load_lora_state_dict(
 
 def _remap_state_dict_keys(sd, rules):
     """
-    Remap keys in a state_dict based on a priority list of substring substitution rules.
+    Remap keys in a state_dict by sequentially applying a list of substring substitution rules.
 
     This utility function transforms parameter names by applying a sequence of
-    (old_substring, new_substring) pairs.
+    (old_substring, new_substring) pairs. For each key in the input dictionary,
+    **all rules are evaluated in the given order**, and every rule whose
+    `old_substring` is found within the current key triggers a replacement.
+    Substitutions are cumulative: the key is updated after each match, and
+    subsequent rules operate on the result of previous replacements.
 
-    For each key in the input dictionary, the `rules` are evaluated in the given order.
-    The **first** rule whose `old_substring` is found within the key triggers a
-    replacement. Once a match occurs, the search stops and no further rules are
-    considered for that key. Keys that do not match any rule are copied unchanged.
+    The order of rules matters; users are responsible for arranging them to
+    achieve the desired final key. Keys that do not match any rule are copied
+    unchanged.
 
     Args:
         sd (dict[str, Any]): Original state_dict mapping parameter names to tensors.
         rules (List[Tuple[str, str]]): A list of (old_substring, new_substring) pairs.
-            Rules are applied sequentially with first-match precedence.
+            Rules are applied sequentially, and **all matching rules are executed**.
 
     Returns:
         dict[str, Any]: A new state_dict with remapped keys. Values are unchanged.
     """
     new_sd = OrderedDict()
     for k, v in sd.items():
+        new_key = k
         matched = False
         for p1, p2 in rules:
             if p1 not in k:
                 continue
-            new_sd[k.replace(p1, p2)] = v
+            new_key = new_key.replace(p1, p2)
             matched = True
-            break
-        if not matched:
+        if matched:
+            new_sd[new_key] = v
+        else:
             new_sd[k] = v
     return new_sd
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -1792,6 +1792,8 @@ class LTX2VideoTransformer3DModel(nn.Module):
             (".audio_attn1.to_qkv", ".audio_attn1.to_k", "k"),
             (".audio_attn1.to_qkv", ".audio_attn1.to_v", "v"),
         ]
+        # Expose packed shard mappings for LoRA handling of fused projections.
+        self.stacked_params_mapping = stacked_params_mapping
 
         params_dict = dict(self.named_parameters())
         tp_size = get_tensor_model_parallel_world_size()

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -31,7 +31,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     get_classifier_free_guidance_world_size,
 )
 from vllm_omni.diffusion.distributed.utils import get_local_device
-from vllm_omni.diffusion.lora.loader import LTX2LoRALoaderMinxin
+from vllm_omni.diffusion.lora.loader import LTX2LoraLoaderMinxin
 from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
@@ -145,7 +145,7 @@ class _VideoAudioScheduler:
         return ((video_out, audio_out),)
 
 
-class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, LTX2LoRALoaderMinxin):
+class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, LTX2LoraLoaderMinxin):
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -1281,6 +1281,7 @@ class LTX2TwoStagesPipeline(nn.Module):
         stage_2_req = copy.copy(req)
         stage_2_req.sampling_params = req.sampling_params.clone()
         stage_2_req.sampling_params.num_inference_steps = 3
+        stage_2_req.guidance_scale = 1.0
 
         video, audio = self.pipe(
             req=stage_2_req,
@@ -1290,7 +1291,6 @@ class LTX2TwoStagesPipeline(nn.Module):
             negative_prompt=negative_prompt,
             noise_scale=STAGE_2_DISTILLED_SIGMA_VALUES[0],
             sigmas=STAGE_2_DISTILLED_SIGMA_VALUES,
-            guidance_scale=1.0,
             generator=generator,
             output_type="np",
             return_dict=False,

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -31,7 +31,7 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     get_classifier_free_guidance_world_size,
 )
 from vllm_omni.diffusion.distributed.utils import get_local_device
-from vllm_omni.diffusion.lora.loader import LTX2LoraLoaderMinxin
+from vllm_omni.diffusion.lora.loader import LTX2LoraLoaderMixin
 from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
@@ -145,7 +145,7 @@ class _VideoAudioScheduler:
         return ((video_out, audio_out),)
 
 
-class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, LTX2LoraLoaderMinxin):
+class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, LTX2LoraLoaderMixin):
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -31,11 +31,11 @@ from vllm_omni.diffusion.distributed.parallel_state import (
     get_classifier_free_guidance_world_size,
 )
 from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.lora.loader import LTX2LoRALoaderMinxin
 from vllm_omni.diffusion.lora.manager import DiffusionLoRAManager
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin
 from vllm_omni.diffusion.request import OmniDiffusionRequest
-from vllm_omni.lora.request import LoRARequest
 
 from .ltx2_transformer import LTX2VideoTransformer3DModel
 from .pipeline_ltx2_latent_upsample import LTX2LatentUpsamplePipeline
@@ -145,7 +145,7 @@ class _VideoAudioScheduler:
         return ((video_out, audio_out),)
 
 
-class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
+class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, LTX2LoRALoaderMinxin):
     def __init__(
         self,
         *,
@@ -1170,8 +1170,6 @@ class LTX2TwoStagesPipeline(nn.Module):
         # will not return the expected directory name, so we need to remove it by normpath
         if "distilled" in os.path.basename(os.path.normpath(self.model_path)):
             self.distilled = True
-        else:
-            raise NotImplementedError(f"{self.model_path} is not supported for {self.__class__.__name__}.")
 
         self.pipe = LTX2Pipeline(od_config=od_config, prefix=prefix)
         self.upsample_pipe = LTX2LatentUpsamplePipeline(
@@ -1261,17 +1259,16 @@ class LTX2TwoStagesPipeline(nn.Module):
             return_dict=False,
         )[0]
 
+        original_scheduler = self.pipe.scheduler
+        lora_loaded = False
         if not self.distilled:
             # Load Stage 2 distilled LoRA
             lora_path = f"{self.model_path}/ltx-2-19b-distilled-lora-384.safetensors"
-            lora_request = LoRARequest(
-                lora_name="stage_2_distilled",
-                lora_int_id=1,
-                lora_path=lora_path,
-            )
-            self.lora_manager.set_active_adapter(lora_request, lora_scale=1.0)
+            self.pipe.load_lora_weights(lora_path, adapter_name="stage_2_distilled")
+            lora_loaded = True
 
             # Change scheduler to use Stage 2 distilled sigmas as is
+            original_scheduler = self.pipe.scheduler
             new_scheduler = FlowMatchEulerDiscreteScheduler.from_config(
                 self.pipe.scheduler.config,
                 use_dynamic_shifting=False,
@@ -1298,6 +1295,11 @@ class LTX2TwoStagesPipeline(nn.Module):
             output_type="np",
             return_dict=False,
         ).output
+
+        if lora_loaded:
+            self.pipe.unload_lora_weights("stage_2_distilled")
+        if original_scheduler is not None:
+            self.pipe.scheduler = original_scheduler
 
         return DiffusionOutput(output=(video, audio))
 

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -245,9 +245,7 @@ def apply_rotary_emb_qwen(
         return x_out.type_as(x)
 
 
-class QwenImagePipeline(
-    nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, QwenImageLoraLoaderMixin
-):
+class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, QwenImageLoraLoaderMixin):
     supports_step_execution: ClassVar[bool] = True
 
     def __init__(

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image.py
@@ -25,6 +25,7 @@ from vllm.model_executor.models.utils import AutoWeightsLoader
 from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_qwenimage import DistributedAutoencoderKLQwenImage
 from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.lora.loader import QwenImageLoraLoaderMixin
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.qwen_image.cfg_parallel import (
     QwenImageCFGParallelMixin,
@@ -244,7 +245,9 @@ def apply_rotary_emb_qwen(
         return x_out.type_as(x)
 
 
-class QwenImagePipeline(nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin):
+class QwenImagePipeline(
+    nn.Module, QwenImageCFGParallelMixin, DiffusionPipelineProfilerMixin, QwenImageLoraLoaderMixin
+):
     supports_step_execution: ClassVar[bool] = True
 
     def __init__(

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2.py
@@ -21,6 +21,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.lora.loader import WanLoraLoaderMixin
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
 from vllm_omni.diffusion.models.schedulers import FlowUniPCMultistepScheduler
@@ -245,7 +246,7 @@ def get_wan22_pre_process_func(
     return pre_process_func
 
 
-class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin):
+class Wan22Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin, WanLoraLoaderMixin):
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
+++ b/vllm_omni/diffusion/models/wan2_2/pipeline_wan2_2_i2v.py
@@ -21,6 +21,7 @@ from vllm_omni.diffusion.data import DiffusionOutput, OmniDiffusionConfig
 from vllm_omni.diffusion.distributed.autoencoders.autoencoder_kl_wan import DistributedAutoencoderKLWan
 from vllm_omni.diffusion.distributed.cfg_parallel import CFGParallelMixin
 from vllm_omni.diffusion.distributed.utils import get_local_device
+from vllm_omni.diffusion.lora.loader import WanLoraLoaderMixin
 from vllm_omni.diffusion.model_loader.diffusers_loader import DiffusersPipelineLoader
 from vllm_omni.diffusion.models.interface import SupportImageInput
 from vllm_omni.diffusion.models.progress_bar import ProgressBarMixin, _is_rank_zero
@@ -159,7 +160,7 @@ def get_wan22_i2v_pre_process_func(
 
 
 class Wan22I2VPipeline(
-    nn.Module, SupportImageInput, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin
+    nn.Module, SupportImageInput, CFGParallelMixin, ProgressBarMixin, DiffusionPipelineProfilerMixin, WanLoraLoaderMixin
 ):
     """
     Wan2.2 Image-to-Video Pipeline.

--- a/vllm_omni/diffusion/worker/diffusion_worker.py
+++ b/vllm_omni/diffusion/worker/diffusion_worker.py
@@ -186,14 +186,20 @@ class DiffusionWorker:
         """Initialize the LoRA manager for this worker."""
         if self.model_runner.pipeline is None:
             return
-        self.lora_manager = DiffusionLoRAManager(
-            pipeline=self.model_runner.pipeline,
-            device=self.device,
-            dtype=self.od_config.dtype,
-            max_cached_adapters=self.od_config.max_cpu_loras,
-            lora_path=self.od_config.lora_path,
-            lora_scale=self.od_config.lora_scale,
-        )
+        try:
+            self.lora_manager = DiffusionLoRAManager(
+                pipeline=self.model_runner.pipeline,
+                device=self.device,
+                dtype=self.od_config.dtype,
+                max_cached_adapters=self.od_config.max_cpu_loras,
+                lora_path=self.od_config.lora_path,
+                lora_scale=self.od_config.lora_scale,
+            )
+        except Exception:
+            # fallback to load distilled LoRA
+            pipeline = self.model_runner.pipeline
+            if hasattr(pipeline, "load_lora_weights"):
+                pipeline.load_lora_weights(self.od_config.lora_path)
 
     def generate(self, request: OmniDiffusionRequest) -> DiffusionOutput:
         """Generate output for the given requests."""


### PR DESCRIPTION
Bot stress test E — 8 files, 592 lines across multiple DiT pipelines (LTX2, QwenImage, Wan2.2). Cross-file speculation trap test.