### PR TITLE
Gate Claude review behind claude-review label

### DIFF
--- a/.github/REVIEW_RULES.md
+++ b/.github/REVIEW_RULES.md
@@ -2,6 +2,22 @@
 
 This file is read by `.github/workflows/claude-review.yml` on every run. Edit this file to tune review behavior — no workflow change needed.
 
+## How to use this bot (for contributors and maintainers)
+
+The bot does NOT auto-review PRs. Trigger it explicitly:
+
+| How | What it does |
+|---|---|
+| Apply label `claude-review` to a PR | One-shot full review |
+| Post `@claude review` (or `take a look`, `ptal`) | Full review (same as label) |
+| Post `@claude why did you flag X?` | Bot answers your question |
+| Post `@claude I disagree — Y handles that` | Bot re-examines its prior comment |
+| Post `@claude look again after my fix` | Bot reviews only what changed |
+| Post `@claude LGTM?` | Bot gives a short verdict |
+| Post `@claude` alone / "thanks" / "👍" | 1-line reply, no review |
+
+Rule of thumb: **label = kick off review, `@claude` = talk to the reviewer**.
+
 ## Who you are
 
 You are a senior code reviewer for vLLM-OMNI, a framework that extends vLLM to omni-modality (text/image/video/audio) inference and serving. You have deep familiarity with:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,11 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-    paths-ignore:
-      - "docs/**"
-      - "**.md"
-      - "examples/**/*.md"
+    types: [labeled]
   issue_comment:
     types: [created]
 
@@ -20,8 +16,13 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Triggered ONLY by:
+    #   1. Applying the `claude-review` label to a PR (one-shot full review), OR
+    #   2. Mentioning `@claude` in a PR comment (Q&A / disagreement / re-review / etc.)
     if: |
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'claude-review') ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@claude'))
@@ -39,12 +40,20 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
             EVENT: ${{ github.event_name }}
+            TRIGGER: ${{ github.event_name == 'pull_request' && 'label-applied' || 'at-claude-comment' }}
             COMMENT BODY: ${{ github.event.comment.body }}
 
             FIRST ACTION (mandatory): read the review rules file at
             `.github/REVIEW_RULES.md` and follow every rule in it. That file is the
             source of truth for persona, intent routing, dedup contract, anti-speculation,
             style, focus areas, and skip list.
+
+            If TRIGGER is `label-applied`, treat this as an explicit FULL REVIEW request
+            (same as the "review request" intent in REVIEW_RULES.md).
+
+            If TRIGGER is `at-claude-comment`, route based on COMMENT BODY per
+            REVIEW_RULES.md Step 2 (review / question / disagreement / re-review /
+            clarification / chit-chat).
 
             Do not improvise review behavior outside what REVIEW_RULES.md specifies.
             If REVIEW_RULES.md is missing, post a single `gh pr comment` saying so and exit.


### PR DESCRIPTION
Change trigger model so bot is opt-in per PR:

- **Remove** auto-trigger on `pull_request: [opened, synchronize]` and the `paths-ignore` filter
- **Add** trigger on `pull_request: types: [labeled]` with `label.name == 'claude-review'`
- **Keep** `@claude` mentions as the conversational channel

UX: apply the `claude-review` label once to kick off a full review, then use `@claude` to ask follow-up questions, challenge findings, or request a re-review after fixes. REVIEW_RULES.md now has a usage cheatsheet at the top.