### PR TITLE
[Test] Limit Qwen-Image-Edit-2511 input image count (upstream #2840, label-gated test)

### DIFF
--- a/tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py
+++ b/tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py
@@ -1,97 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+from pathlib import Path
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
-import torch
+from PIL import Image
 
 from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit_plus import (
-    QwenImageEditPlusPipeline,
+    get_qwen_image_edit_plus_pre_process_func,
 )
 
 pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
 
 
-class _FakeProcessorOutput(SimpleNamespace):
-    def to(self, _device: str):
-        return self
+def test_qwen_image_edit_plus_rejects_too_many_input_images(tmp_path: Path):
+    vae_dir = tmp_path / "vae"
+    vae_dir.mkdir()
+    (vae_dir / "config.json").write_text(json.dumps({"z_dim": 16}))
 
-
-class _FakeProcessor:
-    def __call__(self, *, text, images, padding, return_tensors):
-        assert padding is True
-        assert return_tensors == "pt"
-        assert len(text) == 1
-        assert len(images) == 2
-        return _FakeProcessorOutput(
-            input_ids=torch.tensor([[1, 2, 3, 4]]),
-            attention_mask=torch.tensor([[1, 1, 1, 0]]),
-            pixel_values=torch.tensor([1.0]),
-            image_grid_thw=torch.tensor([[1, 1, 1]]),
-        )
-
-
-class _FakeTextEncoder:
-    dtype = torch.float32
-
-    def __init__(self) -> None:
-        self.model_calls = []
-
-    def __call__(self, *args, **kwargs):
-        raise AssertionError("full CausalLM forward should not be used for prompt encoding")
-
-    def model(self, **kwargs):
-        self.model_calls.append(kwargs)
-        return SimpleNamespace(
-            last_hidden_state=torch.tensor(
-                [
-                    [
-                        [1.0, 1.0, 1.0],
-                        [2.0, 2.0, 2.0],
-                        [3.0, 3.0, 3.0],
-                        [4.0, 4.0, 4.0],
-                    ]
-                ]
-            )
-        )
-
-
-def test_qwen_image_edit_plus_prompt_encoding_skips_lm_head():
-    pipeline = QwenImageEditPlusPipeline.__new__(QwenImageEditPlusPipeline)
-    pipeline.device = "cpu"
-    pipeline.text_encoder = _FakeTextEncoder()
-    pipeline.processor = _FakeProcessor()
-    pipeline.prompt_template_encode = "{}"
-    pipeline.prompt_template_encode_start_idx = 1
-
-    prompt_embeds, attention_mask = pipeline._get_qwen_prompt_embeds(
-        prompt="combine",
-        image=[object(), object()],
+    pre_process = get_qwen_image_edit_plus_pre_process_func(SimpleNamespace(model=str(tmp_path)))
+    image = Image.fromarray(np.zeros((32, 32, 3), dtype=np.uint8))
+    request = SimpleNamespace(
+        prompts=[
+            {
+                "prompt": "combine",
+                "multi_modal_data": {"image": [image, image, image, image, image]},
+            }
+        ],
+        sampling_params=SimpleNamespace(height=None, width=None),
     )
 
-    assert len(pipeline.text_encoder.model_calls) == 1
-    model_call = pipeline.text_encoder.model_calls[0]
-    assert model_call["output_hidden_states"] is False
-    assert model_call["return_dict"] is True
-    assert tuple(prompt_embeds.shape) == (1, 2, 3)
-    assert tuple(attention_mask.shape) == (1, 2)
-    assert torch.equal(prompt_embeds[0], torch.tensor([[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]))
-    assert torch.equal(attention_mask[0], torch.tensor([1, 1]))
-
-
-def test_qwen_image_edit_plus_encode_prompt_applies_max_sequence_length():
-    pipeline = QwenImageEditPlusPipeline.__new__(QwenImageEditPlusPipeline)
-    pipeline._get_qwen_prompt_embeds = lambda *args, **kwargs: (
-        torch.arange(24, dtype=torch.float32).view(1, 4, 6),
-        torch.tensor([[1, 1, 1, 1]]),
-    )
-
-    prompt_embeds, attention_mask = pipeline.encode_prompt(
-        prompt="combine",
-        image=[object()],
-        max_sequence_length=2,
-    )
-
-    assert tuple(prompt_embeds.shape) == (1, 2, 6)
-    assert tuple(attention_mask.shape) == (1, 2)
-    assert torch.equal(attention_mask[0], torch.tensor([1, 1]))
+    with pytest.raises(ValueError, match=r"At most 4 images are supported by this model"):
+        pre_process(request)

--- a/tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py
+++ b/tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py
@@ -77,3 +77,21 @@ def test_qwen_image_edit_plus_prompt_encoding_skips_lm_head():
     assert tuple(attention_mask.shape) == (1, 2)
     assert torch.equal(prompt_embeds[0], torch.tensor([[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]))
     assert torch.equal(attention_mask[0], torch.tensor([1, 1]))
+
+
+def test_qwen_image_edit_plus_encode_prompt_applies_max_sequence_length():
+    pipeline = QwenImageEditPlusPipeline.__new__(QwenImageEditPlusPipeline)
+    pipeline._get_qwen_prompt_embeds = lambda *args, **kwargs: (
+        torch.arange(24, dtype=torch.float32).view(1, 4, 6),
+        torch.tensor([[1, 1, 1, 1]]),
+    )
+
+    prompt_embeds, attention_mask = pipeline.encode_prompt(
+        prompt="combine",
+        image=[object()],
+        max_sequence_length=2,
+    )
+
+    assert tuple(prompt_embeds.shape) == (1, 2, 6)
+    assert tuple(attention_mask.shape) == (1, 2)
+    assert torch.equal(attention_mask[0], torch.tensor([1, 1]))

--- a/tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py
+++ b/tests/diffusion/models/qwen_image/test_qwen_image_edit_plus.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit_plus import (
+    QwenImageEditPlusPipeline,
+)
+
+pytestmark = [pytest.mark.core_model, pytest.mark.diffusion, pytest.mark.cpu]
+
+
+class _FakeProcessorOutput(SimpleNamespace):
+    def to(self, _device: str):
+        return self
+
+
+class _FakeProcessor:
+    def __call__(self, *, text, images, padding, return_tensors):
+        assert padding is True
+        assert return_tensors == "pt"
+        assert len(text) == 1
+        assert len(images) == 2
+        return _FakeProcessorOutput(
+            input_ids=torch.tensor([[1, 2, 3, 4]]),
+            attention_mask=torch.tensor([[1, 1, 1, 0]]),
+            pixel_values=torch.tensor([1.0]),
+            image_grid_thw=torch.tensor([[1, 1, 1]]),
+        )
+
+
+class _FakeTextEncoder:
+    dtype = torch.float32
+
+    def __init__(self) -> None:
+        self.model_calls = []
+
+    def __call__(self, *args, **kwargs):
+        raise AssertionError("full CausalLM forward should not be used for prompt encoding")
+
+    def model(self, **kwargs):
+        self.model_calls.append(kwargs)
+        return SimpleNamespace(
+            last_hidden_state=torch.tensor(
+                [
+                    [
+                        [1.0, 1.0, 1.0],
+                        [2.0, 2.0, 2.0],
+                        [3.0, 3.0, 3.0],
+                        [4.0, 4.0, 4.0],
+                    ]
+                ]
+            )
+        )
+
+
+def test_qwen_image_edit_plus_prompt_encoding_skips_lm_head():
+    pipeline = QwenImageEditPlusPipeline.__new__(QwenImageEditPlusPipeline)
+    pipeline.device = "cpu"
+    pipeline.text_encoder = _FakeTextEncoder()
+    pipeline.processor = _FakeProcessor()
+    pipeline.prompt_template_encode = "{}"
+    pipeline.prompt_template_encode_start_idx = 1
+
+    prompt_embeds, attention_mask = pipeline._get_qwen_prompt_embeds(
+        prompt="combine",
+        image=[object(), object()],
+    )
+
+    assert len(pipeline.text_encoder.model_calls) == 1
+    model_call = pipeline.text_encoder.model_calls[0]
+    assert model_call["output_hidden_states"] is False
+    assert model_call["return_dict"] is True
+    assert tuple(prompt_embeds.shape) == (1, 2, 3)
+    assert tuple(attention_mask.shape) == (1, 2)
+    assert torch.equal(prompt_embeds[0], torch.tensor([[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]))
+    assert torch.equal(attention_mask[0], torch.tensor([1, 1]))

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -782,6 +782,30 @@ def test_image_edit_rejects_multiple_images_when_model_does_not_support_them(asy
     assert engine.captured_prompt is None
 
 
+def test_image_edit_rejects_too_many_images_for_qwen_image_edit_2511(async_omni_test_client):
+    engine = async_omni_test_client.app.state.engine_client
+    engine.get_diffusion_od_config = lambda: SimpleNamespace(
+        supports_multimodal_inputs=True,
+        model="Qwen/Qwen-Image-Edit-2511",
+    )
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[
+            ("image", make_test_image_bytes((16, 16))),
+            ("image", make_test_image_bytes((16, 16))),
+            ("image", make_test_image_bytes((16, 16))),
+            ("image", make_test_image_bytes((16, 16))),
+            ("image", make_test_image_bytes((16, 16))),
+        ],
+        data={"prompt": "hello world."},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Received 5 input images. At most 4 images are supported by this model."
+    assert engine.captured_prompt is None
+
+
 def test_image_edit_parameter_pass(async_omni_test_client):
     img_bytes_1 = make_test_image_bytes((16, 16))
 

--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -806,6 +806,39 @@ def test_image_edit_rejects_too_many_images_for_qwen_image_edit_2511(async_omni_
     assert engine.captured_prompt is None
 
 
+def test_image_edit_rejects_too_many_images_for_qwen_image_edit_2511_before_loading(
+    async_omni_test_client, monkeypatch: pytest.MonkeyPatch
+):
+    import vllm_omni.entrypoints.openai.api_server as api_server_module
+
+    engine = async_omni_test_client.app.state.engine_client
+    engine.get_diffusion_od_config = lambda: SimpleNamespace(
+        supports_multimodal_inputs=True,
+        model="Qwen/Qwen-Image-Edit-2511",
+    )
+
+    def _fail_load(*args, **kwargs):
+        raise AssertionError("_load_input_images should not run for over-limit requests")
+
+    monkeypatch.setattr(api_server_module, "_load_input_images", _fail_load)
+
+    response = async_omni_test_client.post(
+        "/v1/images/edits",
+        files=[
+            ("image", make_test_image_bytes((16, 16))),
+            ("image", make_test_image_bytes((16, 16))),
+            ("image", make_test_image_bytes((16, 16))),
+            ("image", make_test_image_bytes((16, 16))),
+            ("image", make_test_image_bytes((16, 16))),
+        ],
+        data={"prompt": "hello world."},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Received 5 input images. At most 4 images are supported by this model."
+    assert engine.captured_prompt is None
+
+
 def test_image_edit_parameter_pass(async_omni_test_client):
     img_bytes_1 = make_test_image_bytes((16, 16))
 

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -384,6 +384,9 @@ class QwenImageEditPlusPipeline(
         if prompt_embeds is None:
             prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt, image)
 
+        prompt_embeds = prompt_embeds[:, :max_sequence_length]
+        prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
+
         _, seq_len, _ = prompt_embeds.shape
         prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)
         prompt_embeds = prompt_embeds.view(batch_size * num_images_per_prompt, seq_len, -1)

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -328,15 +328,18 @@ class QwenImageEditPlusPipeline(
             return_tensors="pt",
         ).to(self.device)
 
-        outputs = self.text_encoder(
+        # We only need the fused multimodal hidden states for diffusion conditioning.
+        # Calling the full CausalLM forward also materializes logits for the entire
+        # prompt, which becomes unnecessarily expensive for many-image edit prompts.
+        outputs = self.text_encoder.model(
             input_ids=model_inputs.input_ids,
             attention_mask=model_inputs.attention_mask,
             pixel_values=model_inputs.pixel_values,
             image_grid_thw=model_inputs.image_grid_thw,
-            output_hidden_states=True,
+            output_hidden_states=False,
+            return_dict=True,
         )
-
-        hidden_states = outputs.hidden_states[-1]
+        hidden_states = outputs.last_hidden_state
         split_hidden_states = self._extract_masked_hidden(hidden_states, model_inputs.attention_mask)
         split_hidden_states = [e[drop_idx:] for e in split_hidden_states]
         attn_mask_list = [torch.ones(e.size(0), dtype=torch.long, device=e.device) for e in split_hidden_states]
@@ -348,7 +351,7 @@ class QwenImageEditPlusPipeline(
             [torch.cat([u, u.new_zeros(max_seq_len - u.size(0))]) for u in attn_mask_list]
         )
 
-        prompt_embeds = prompt_embeds.to(dtype=dtype)
+        prompt_embeds = prompt_embeds.to(dtype=dtype, device=self.device)
 
         return prompt_embeds, encoder_attention_mask
 

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -53,6 +53,9 @@ logger = logging.getLogger(__name__)
 
 CONDITION_IMAGE_SIZE = 384 * 384
 VAE_IMAGE_SIZE = 1024 * 1024
+# Keep this in sync with the practical conditioning-token budget for
+# Qwen-Image-Edit-2511. Empirically, 4 images stays within the supported range
+# while 5 images overflows the prompt/conditioning path and fails downstream.
 MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES = 4
 
 

--- a/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
+++ b/vllm_omni/diffusion/models/qwen_image/pipeline_qwen_image_edit_plus.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 
 CONDITION_IMAGE_SIZE = 384 * 384
 VAE_IMAGE_SIZE = 1024 * 1024
+MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES = 4
 
 
 def get_qwen_image_edit_plus_pre_process_func(
@@ -90,6 +91,11 @@ def get_qwen_image_edit_plus_pre_process_func(
 
             if not isinstance(raw_image, list):
                 raw_image = [raw_image]
+            if len(raw_image) > MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES:
+                raise ValueError(
+                    f"Received {len(raw_image)} input images. "
+                    f"At most {MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES} images are supported by this model."
+                )
             image = [
                 PIL.Image.open(im) if isinstance(im, str) else cast(PIL.Image.Image | np.ndarray | torch.Tensor, im)
                 for im in raw_image
@@ -328,18 +334,15 @@ class QwenImageEditPlusPipeline(
             return_tensors="pt",
         ).to(self.device)
 
-        # We only need the fused multimodal hidden states for diffusion conditioning.
-        # Calling the full CausalLM forward also materializes logits for the entire
-        # prompt, which becomes unnecessarily expensive for many-image edit prompts.
-        outputs = self.text_encoder.model(
+        outputs = self.text_encoder(
             input_ids=model_inputs.input_ids,
             attention_mask=model_inputs.attention_mask,
             pixel_values=model_inputs.pixel_values,
             image_grid_thw=model_inputs.image_grid_thw,
-            output_hidden_states=False,
-            return_dict=True,
+            output_hidden_states=True,
         )
-        hidden_states = outputs.last_hidden_state
+
+        hidden_states = outputs.hidden_states[-1]
         split_hidden_states = self._extract_masked_hidden(hidden_states, model_inputs.attention_mask)
         split_hidden_states = [e[drop_idx:] for e in split_hidden_states]
         attn_mask_list = [torch.ones(e.size(0), dtype=torch.long, device=e.device) for e in split_hidden_states]
@@ -351,7 +354,7 @@ class QwenImageEditPlusPipeline(
             [torch.cat([u, u.new_zeros(max_seq_len - u.size(0))]) for u in attn_mask_list]
         )
 
-        prompt_embeds = prompt_embeds.to(dtype=dtype, device=self.device)
+        prompt_embeds = prompt_embeds.to(dtype=dtype)
 
         return prompt_embeds, encoder_attention_mask
 
@@ -383,9 +386,6 @@ class QwenImageEditPlusPipeline(
 
         if prompt_embeds is None:
             prompt_embeds, prompt_embeds_mask = self._get_qwen_prompt_embeds(prompt, image)
-
-        prompt_embeds = prompt_embeds[:, :max_sequence_length]
-        prompt_embeds_mask = prompt_embeds_mask[:, :max_sequence_length]
 
         _, seq_len, _ = prompt_embeds.shape
         prompt_embeds = prompt_embeds.repeat(1, num_images_per_prompt, 1)

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1647,7 +1647,11 @@ def _get_engine_and_model(raw_request: Request):
 
 
 def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) -> bool:
-    od_config = _get_diffusion_od_config(raw_request, engine_client)
+    diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None) or engine_client
+    get_diffusion_od_config = getattr(diffusion_engine, "get_diffusion_od_config", None)
+    od_config = (
+        get_diffusion_od_config() if callable(get_diffusion_od_config) else getattr(diffusion_engine, "od_config", None)
+    )
 
     if od_config is None:
         # Preserve the existing compatibility behavior when the diffusion
@@ -1656,25 +1660,11 @@ def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) 
     return bool(getattr(od_config, "supports_multimodal_inputs", False))
 
 
-def _get_diffusion_od_config(raw_request: Request, engine_client: Any) -> Any:
-    diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None) or engine_client
-    get_diffusion_od_config = getattr(diffusion_engine, "get_diffusion_od_config", None)
-    return (
-        get_diffusion_od_config() if callable(get_diffusion_od_config) else getattr(diffusion_engine, "od_config", None)
-    )
-
-
-def _get_max_edit_input_images(raw_request: Request, engine_client: Any, model_name: str) -> int | None:
+def _get_max_edit_input_images(raw_request: Request, engine_client: Any, model_name: str) -> int:
     if not _supports_multimodal_image_inputs(raw_request, engine_client):
         return 1
 
-    od_config = _get_diffusion_od_config(raw_request, engine_client)
-    model_identifiers = [model_name, getattr(od_config, "model", None)]
-
-    if any(isinstance(identifier, str) and "Qwen-Image-Edit-2511" in identifier for identifier in model_identifiers):
-        return 4
-
-    return None
+    return 4
 
 
 def _get_lora_from_json_str(lora_body):

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1471,16 +1471,16 @@ async def edit_images(
         if not input_images_list:
             raise HTTPException(status_code=422, detail="Field 'image' or 'url' is required")
         pil_images = await _load_input_images(input_images_list)
-        if len(pil_images) > 1 and not _supports_multimodal_image_inputs(raw_request, engine_client):
-            raise HTTPException(
-                status_code=HTTPStatus.BAD_REQUEST.value,
-                detail="Received multiple input images. Only a single image is supported by this model.",
-            )
         max_input_images = _get_max_edit_input_images(raw_request, engine_client, model_name)
         if max_input_images is not None and len(pil_images) > max_input_images:
+            detail = (
+                "Received multiple input images. Only a single image is supported by this model."
+                if max_input_images == 1
+                else f"Received {len(pil_images)} input images. At most {max_input_images} images are supported by this model."
+            )
             raise HTTPException(
                 status_code=HTTPStatus.BAD_REQUEST.value,
-                detail=f"Received {len(pil_images)} input images. At most {max_input_images} images are supported by this model.",
+                detail=detail,
             )
         prompt["multi_modal_data"] = {}
         prompt["multi_modal_data"]["image"] = pil_images
@@ -1647,11 +1647,7 @@ def _get_engine_and_model(raw_request: Request):
 
 
 def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) -> bool:
-    diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None) or engine_client
-    get_diffusion_od_config = getattr(diffusion_engine, "get_diffusion_od_config", None)
-    od_config = (
-        get_diffusion_od_config() if callable(get_diffusion_od_config) else getattr(diffusion_engine, "od_config", None)
-    )
+    od_config = _get_diffusion_od_config(raw_request, engine_client)
 
     if od_config is None:
         # Preserve the existing compatibility behavior when the diffusion
@@ -1660,16 +1656,20 @@ def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) 
     return bool(getattr(od_config, "supports_multimodal_inputs", False))
 
 
-def _get_max_edit_input_images(raw_request: Request, engine_client: Any, model_name: str) -> int | None:
+def _get_diffusion_od_config(raw_request: Request, engine_client: Any) -> Any:
     diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None) or engine_client
     get_diffusion_od_config = getattr(diffusion_engine, "get_diffusion_od_config", None)
-    od_config = (
+    return (
         get_diffusion_od_config() if callable(get_diffusion_od_config) else getattr(diffusion_engine, "od_config", None)
     )
 
-    model_identifiers = [model_name]
-    if od_config is not None:
-        model_identifiers.append(getattr(od_config, "model", None))
+
+def _get_max_edit_input_images(raw_request: Request, engine_client: Any, model_name: str) -> int | None:
+    if not _supports_multimodal_image_inputs(raw_request, engine_client):
+        return 1
+
+    od_config = _get_diffusion_od_config(raw_request, engine_client)
+    model_identifiers = [model_name, getattr(od_config, "model", None)]
 
     if any(isinstance(identifier, str) and "Qwen-Image-Edit-2511" in identifier for identifier in model_identifiers):
         return 4

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1470,6 +1470,9 @@ async def edit_images(
             input_images_list.extend(urls)
         if not input_images_list:
             raise HTTPException(status_code=422, detail="Field 'image' or 'url' is required")
+        # Reject oversized multi-image edit requests before fetching or decoding
+        # any inputs. This keeps over-limit URL requests from burning network,
+        # CPU, and memory on work that will be rejected anyway.
         max_input_images = _get_max_edit_input_images(raw_request, engine_client, model_name)
         if max_input_images is not None and len(input_images_list) > max_input_images:
             detail = (
@@ -1671,6 +1674,10 @@ def _get_max_edit_input_images(raw_request: Request, engine_client: Any, model_n
     if not _supports_multimodal_image_inputs(raw_request, engine_client):
         return 1
 
+    # Keep the API-side limit model-specific: this helper should not hardcode a
+    # generic "multi-image means 4" rule because future edit pipelines may have
+    # different conditioning budgets. Query the serving model / OD config first,
+    # then defer to the owning pipeline constant.
     od_config = _get_diffusion_od_config(raw_request, engine_client)
     model_identifiers = [model_name]
     if od_config is not None:

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1470,14 +1470,13 @@ async def edit_images(
             input_images_list.extend(urls)
         if not input_images_list:
             raise HTTPException(status_code=422, detail="Field 'image' or 'url' is required")
-        pil_images = await _load_input_images(input_images_list)
         max_input_images = _get_max_edit_input_images(raw_request, engine_client, model_name)
-        if max_input_images is not None and len(pil_images) > max_input_images:
+        if max_input_images is not None and len(input_images_list) > max_input_images:
             detail = (
                 "Received multiple input images. Only a single image is supported by this model."
                 if max_input_images == 1
                 else (
-                    f"Received {len(pil_images)} input images. "
+                    f"Received {len(input_images_list)} input images. "
                     f"At most {max_input_images} images are supported by this model."
                 )
             )
@@ -1485,6 +1484,7 @@ async def edit_images(
                 status_code=HTTPStatus.BAD_REQUEST.value,
                 detail=detail,
             )
+        pil_images = await _load_input_images(input_images_list)
         prompt["multi_modal_data"] = {}
         prompt["multi_modal_data"]["image"] = pil_images
 

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1721,11 +1721,17 @@ async def _generate_with_async_omni(
                 pass
         sampling_params_list.append(default_stage_params)
 
-    async for output in engine_client.generate(
-        sampling_params_list=sampling_params_list,
-        **kwargs,
-    ):
-        result = output
+    try:
+        async for output in engine_client.generate(
+            sampling_params_list=sampling_params_list,
+            **kwargs,
+        ):
+            result = output
+    except RuntimeError as e:
+        payload = e.args[0] if e.args else None
+        if isinstance(payload, dict) and "error" in payload:
+            raise ValueError(str(payload["error"])) from e
+        raise
 
     if result is None:
         raise HTTPException(

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1476,6 +1476,12 @@ async def edit_images(
                 status_code=HTTPStatus.BAD_REQUEST.value,
                 detail="Received multiple input images. Only a single image is supported by this model.",
             )
+        max_input_images = _get_max_edit_input_images(raw_request, engine_client, model_name)
+        if max_input_images is not None and len(pil_images) > max_input_images:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST.value,
+                detail=f"Received {len(pil_images)} input images. At most {max_input_images} images are supported by this model.",
+            )
         prompt["multi_modal_data"] = {}
         prompt["multi_modal_data"]["image"] = pil_images
 
@@ -1654,6 +1660,23 @@ def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) 
     return bool(getattr(od_config, "supports_multimodal_inputs", False))
 
 
+def _get_max_edit_input_images(raw_request: Request, engine_client: Any, model_name: str) -> int | None:
+    diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None) or engine_client
+    get_diffusion_od_config = getattr(diffusion_engine, "get_diffusion_od_config", None)
+    od_config = (
+        get_diffusion_od_config() if callable(get_diffusion_od_config) else getattr(diffusion_engine, "od_config", None)
+    )
+
+    model_identifiers = [model_name]
+    if od_config is not None:
+        model_identifiers.append(getattr(od_config, "model", None))
+
+    if any(isinstance(identifier, str) and "Qwen-Image-Edit-2511" in identifier for identifier in model_identifiers):
+        return 4
+
+    return None
+
+
 def _get_lora_from_json_str(lora_body):
     if lora_body is None:
         return None
@@ -1721,17 +1744,11 @@ async def _generate_with_async_omni(
                 pass
         sampling_params_list.append(default_stage_params)
 
-    try:
-        async for output in engine_client.generate(
-            sampling_params_list=sampling_params_list,
-            **kwargs,
-        ):
-            result = output
-    except RuntimeError as e:
-        payload = e.args[0] if e.args else None
-        if isinstance(payload, dict) and "error" in payload:
-            raise ValueError(str(payload["error"])) from e
-        raise
+    async for output in engine_client.generate(
+        sampling_params_list=sampling_params_list,
+        **kwargs,
+    ):
+        result = output
 
     if result is None:
         raise HTTPException(

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1650,11 +1650,7 @@ def _get_engine_and_model(raw_request: Request):
 
 
 def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) -> bool:
-    diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None) or engine_client
-    get_diffusion_od_config = getattr(diffusion_engine, "get_diffusion_od_config", None)
-    od_config = (
-        get_diffusion_od_config() if callable(get_diffusion_od_config) else getattr(diffusion_engine, "od_config", None)
-    )
+    od_config = _get_diffusion_od_config(raw_request, engine_client)
 
     if od_config is None:
         # Preserve the existing compatibility behavior when the diffusion
@@ -1663,11 +1659,31 @@ def _supports_multimodal_image_inputs(raw_request: Request, engine_client: Any) 
     return bool(getattr(od_config, "supports_multimodal_inputs", False))
 
 
-def _get_max_edit_input_images(raw_request: Request, engine_client: Any, model_name: str) -> int:
+def _get_diffusion_od_config(raw_request: Request, engine_client: Any) -> Any:
+    diffusion_engine = getattr(raw_request.app.state, "diffusion_engine", None) or engine_client
+    get_diffusion_od_config = getattr(diffusion_engine, "get_diffusion_od_config", None)
+    return (
+        get_diffusion_od_config() if callable(get_diffusion_od_config) else getattr(diffusion_engine, "od_config", None)
+    )
+
+
+def _get_max_edit_input_images(raw_request: Request, engine_client: Any, model_name: str) -> int | None:
     if not _supports_multimodal_image_inputs(raw_request, engine_client):
         return 1
 
-    return 4
+    od_config = _get_diffusion_od_config(raw_request, engine_client)
+    model_identifiers = [model_name]
+    if od_config is not None:
+        model_identifiers.append(getattr(od_config, "model", None))
+
+    if any(isinstance(identifier, str) and "Qwen-Image-Edit-2511" in identifier for identifier in model_identifiers):
+        from vllm_omni.diffusion.models.qwen_image.pipeline_qwen_image_edit_plus import (
+            MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES,
+        )
+
+        return MAX_QWEN_IMAGE_EDIT_PLUS_INPUT_IMAGES
+
+    return None
 
 
 def _get_lora_from_json_str(lora_body):

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1476,7 +1476,10 @@ async def edit_images(
             detail = (
                 "Received multiple input images. Only a single image is supported by this model."
                 if max_input_images == 1
-                else f"Received {len(pil_images)} input images. At most {max_input_images} images are supported by this model."
+                else (
+                    f"Received {len(pil_images)} input images. "
+                    f"At most {max_input_images} images are supported by this model."
+                )
             )
             raise HTTPException(
                 status_code=HTTPStatus.BAD_REQUEST.value,


### PR DESCRIPTION
Final test of the label-gated trigger: bot should NOT review on PR open, only after `claude-review` label is applied.