### PR TITLE
[Manual Test] NPU pipeline config (upstream #2857 mirror)

### DIFF
--- a/.buildkite/pipeline-npu.yaml
+++ b/.buildkite/pipeline-npu.yaml
@@ -79,8 +79,10 @@ steps:
       echo "--- Image pushed successfully"
       echo "$${IMAGE_REGISTRY}/$${IMAGE_NAME}:$${VLLM_IMAGE_TAG}"
 
-  - label: "Upload Test Pipeline"
+  - label: "Upload Ready Pipeline"
     depends_on: image-build
+    key: upload-ready-pipeline
+    if: build.branch != "main" && build.pull_request.labels includes "ready"
     agents:
       queue: "linux-aarch64-a2b3-1"
     command: |

--- a/.buildkite/pipeline-npu.yaml
+++ b/.buildkite/pipeline-npu.yaml
@@ -2,7 +2,8 @@ steps:
   - label: ":buildkit: Build and Push NPU Test Image"
     key: image-build
     agents:
-      queue: "linux-aarch64-a2b3-1"
+      queue: "ascend-a3"
+      resource_class: "npu-2"
     plugins:
       - kubernetes:
           metadata:
@@ -84,7 +85,8 @@ steps:
     key: upload-ready-pipeline
     if: build.branch != "main" && build.pull_request.labels includes "ready"
     agents:
-      queue: "linux-aarch64-a2b3-1"
+      queue: "ascend-a3"
+      resource_class: "npu-2"
     command: |
       buildkite-agent pipeline upload .buildkite/test-npu-ready.yaml
       

--- a/.buildkite/pipeline-npu.yaml
+++ b/.buildkite/pipeline-npu.yaml
@@ -1,0 +1,88 @@
+steps:
+  - label: ":buildkit: Build and Push NPU Test Image"
+    key: image-build
+    agents:
+      queue: "linux-aarch64-a2b3-1"
+    plugins:
+      - kubernetes:
+          metadata:
+            annotations:
+              vault.hashicorp.com/agent-init-first: "true"
+              vault.hashicorp.com/agent-inject: "true"
+              vault.hashicorp.com/agent-inject-perms-ca.pem: "0400"
+              vault.hashicorp.com/agent-inject-perms-cert.pem: "0400"
+              vault.hashicorp.com/agent-inject-perms-config.json: "0400"
+              vault.hashicorp.com/agent-inject-perms-key.pem: "0400"
+              vault.hashicorp.com/agent-inject-secret-ca.pem: internal/data/ascend/buildkitd
+              vault.hashicorp.com/agent-inject-secret-cert.pem: internal/data/ascend/buildkitd
+              vault.hashicorp.com/agent-inject-secret-config.json: internal/data/ascend/buildkitd
+              vault.hashicorp.com/agent-inject-secret-key.pem: internal/data/ascend/buildkitd
+              vault.hashicorp.com/agent-inject-template-ca.pem: "{{- with secret \"internal/data/ascend/buildkitd\" -}}\n{{ .Data.data.RootCA }}\n{{- end }}"
+              vault.hashicorp.com/agent-inject-template-cert.pem: "{{- with secret \"internal/data/ascend/buildkitd\" -}}\n{{ .Data.data.ClientCaCert }}\n{{- end }}"
+              vault.hashicorp.com/agent-inject-template-config.json: "{{- with secret \"internal/data/ascend/buildkitd\" -}}\n{{ .Data.data.dockerConfig }}\n{{- end }}"
+              vault.hashicorp.com/agent-inject-template-key.pem: "{{- with secret \"internal/data/ascend/buildkitd\" -}}\n{{ .Data.data.ClientCaKey }}\n{{- end }}"
+              vault.hashicorp.com/agent-pre-populate-only: "true"
+              vault.hashicorp.com/agent-run-as-group: "1000"
+              vault.hashicorp.com/agent-run-as-user: "1000"
+              vault.hashicorp.com/agent-service-account-token-volume-name: token-vol
+              vault.hashicorp.com/role: ascend-gha-runners
+              vault.hashicorp.com/secret-volume-path: /home/user/.docker/
+              vault.hashicorp.com/tls-skip-verify: "true"
+          podSpecPatch:
+            volumes:
+            - name: token-vol
+              projected:
+                defaultMode: 420
+                sources:
+                - serviceAccountToken:
+                    audience: api
+                    expirationSeconds: 600
+                    path: token
+    env:
+      VLLM_IMAGE_TAG: "${BUILDKITE_COMMIT}"
+      IMAGE_NAME: "vllm-omni-ci-npu"
+      IMAGE_REGISTRY: "swr.cn-southwest-2.myhuaweicloud.com/modelfoundry"
+      BUILDKITD_ADDR: "tcp://buildkitd-service.buildkitd:1234"
+    command: |
+      set -ex
+
+      echo "--- Building and pushing NPU Test Image"
+      echo "Image: $${IMAGE_REGISTRY}/$${IMAGE_NAME}:$${VLLM_IMAGE_TAG}"
+      echo "buildkitd address: $${BUILDKITD_ADDR}"
+
+      git config --global url."https://gh-proxy.test.osinfra.cn/https://github.com/".insteadOf "https://github.com/"
+
+      if ! command -v buildctl &> /dev/null; then
+        echo "Installing buildctl..."
+        mkdir -p /tmp/buildkit
+        BUILDKIT_VERSION="v0.29.0"
+        wget -q "https://gh-proxy.test.osinfra.cn/https://github.com/moby/buildkit/releases/download/$${BUILDKIT_VERSION}/buildkit-$${BUILDKIT_VERSION}.linux-arm64.tar.gz" -O /tmp/buildkit.tar.gz
+        tar -xzf /tmp/buildkit.tar.gz -C /tmp/buildkit
+        cp /tmp/buildkit/bin/buildctl /usr/local/bin/
+      fi
+
+      export DOCKER_CONFIG=/home/user/.docker
+      buildctl \
+        --addr="$${BUILDKITD_ADDR}" \
+        --tlscacert=/home/user/.docker/ca.pem \
+        --tlscert=/home/user/.docker/cert.pem \
+        --tlskey=/home/user/.docker/key.pem \
+        build \
+        --frontend dockerfile.v0 \
+        --local context=. \
+        --local dockerfile=./docker \
+        --opt filename=Dockerfile.npu.test \
+        --secret id=dockerconfig,src=/home/user/.docker/config.json \
+        --output type=image,name=$${IMAGE_REGISTRY}/$${IMAGE_NAME}:$${VLLM_IMAGE_TAG},push=true \
+        --progress=plain
+
+      echo "--- Image pushed successfully"
+      echo "$${IMAGE_REGISTRY}/$${IMAGE_NAME}:$${VLLM_IMAGE_TAG}"
+
+  - label: "Upload Test Pipeline"
+    depends_on: image-build
+    agents:
+      queue: "linux-aarch64-a2b3-1"
+    command: |
+      buildkite-agent pipeline upload .buildkite/test-npu-ready.yaml
+      

--- a/.buildkite/test-npu-ready.yaml
+++ b/.buildkite/test-npu-ready.yaml
@@ -1,0 +1,13 @@
+steps:
+  - label: "Simple Unit Test"
+    depends_on: upload-ready-pipeline
+    agents:
+      queue: "linux-aarch64-a2b3-1"
+    image: "swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/vllm-omni-ci-npu:${BUILDKITE_COMMIT}"
+    plugins:
+      - kubernetes:
+          podSpecPatch:
+            imagePullSecrets:
+            - name: swr-secret
+    commands:
+      - "timeout 20m pytest -v -s -m 'core_model and cpu' --cov=vllm_omni --cov-branch --cov-report=term-missing --cov-report=html --cov-report=xml"

--- a/.buildkite/test-npu-ready.yaml
+++ b/.buildkite/test-npu-ready.yaml
@@ -2,7 +2,8 @@ steps:
   - label: "Simple Unit Test"
     depends_on: upload-ready-pipeline
     agents:
-      queue: "linux-aarch64-a2b3-1"
+      queue: "ascend-a3"
+      resource_class: "npu-2"
     image: "swr.cn-southwest-2.myhuaweicloud.com/modelfoundry/vllm-omni-ci-npu:${BUILDKITE_COMMIT}"
     plugins:
       - kubernetes:


### PR DESCRIPTION
Manual label-trigger test for the Claude review bot.

**To trigger the bot:** apply the `claude-review` label to this PR.

Then try these `@claude` follow-ups in the comments:
- `@claude why did you flag X?` — test question mode
- `@claude I disagree because Y` — test disagreement mode
- `@claude LGTM?` — test short-verdict mode

Mirrors upstream vllm-project/vllm-omni#2857 (`Pipeline npu` — NPU buildkite config, 2 files / 106 lines). Do not merge.