### PR TITLE
Route Claude bot to Opus/Sonnet/Haiku by trigger

### DIFF
--- a/.github/REVIEW_RULES.md
+++ b/.github/REVIEW_RULES.md
@@ -4,19 +4,26 @@ This file is read by `.github/workflows/claude-review.yml` on every run. Edit th
 
 ## How to use this bot (for contributors and maintainers)
 
-The bot does NOT auto-review PRs. Trigger it explicitly:
+The bot does NOT auto-review PRs. Trigger it explicitly. Three tiers, picked by trigger:
 
-| How | What it does |
+| Trigger | Model | Use for |
+|---|---|---|
+| Label `claude-review` | **Opus 4.7** (deep) | Full review on non-trivial PRs — correctness, API design, perf, test gaps |
+| Label `claude-quick` | **Haiku 4.5** (cheap) | Fast triage — LGTM check on tiny PRs, obvious-issues-only scan |
+| `@claude <anything>` in a PR comment | **Sonnet 4.6** (balanced) | Conversation — follow-up questions, disagreement, re-review |
+
+### `@claude` command menu (all Sonnet)
+
+| Say | Bot does |
 |---|---|
-| Apply label `claude-review` to a PR | One-shot full review |
-| Post `@claude review` (or `take a look`, `ptal`) | Full review (same as label) |
-| Post `@claude why did you flag X?` | Bot answers your question |
-| Post `@claude I disagree — Y handles that` | Bot re-examines its prior comment |
-| Post `@claude look again after my fix` | Bot reviews only what changed |
-| Post `@claude LGTM?` | Bot gives a short verdict |
-| Post `@claude` alone / "thanks" / "👍" | 1-line reply, no review |
+| `@claude review` / `ptal` / `take a look` | Full review |
+| `@claude why did you flag X?` | Answer the question, no re-review |
+| `@claude I disagree — Y handles that` | Re-examine its prior comment |
+| `@claude look again after my fix` | Review only what changed |
+| `@claude LGTM?` | Short verdict |
+| `@claude` alone / "thanks" / "👍" | 1-line reply |
 
-Rule of thumb: **label = kick off review, `@claude` = talk to the reviewer**.
+Rule of thumb: **label = kick off review (pick tier by PR weight), `@claude` = talk to the reviewer**.
 
 ## Who you are
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,12 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Triggered ONLY by:
-    #   1. Applying the `claude-review` label to a PR (one-shot full review), OR
-    #   2. Mentioning `@claude` in a PR comment (Q&A / disagreement / re-review / etc.)
+    #   1. Label `claude-review` (deep review, Opus 4.7)
+    #   2. Label `claude-quick`  (fast triage, Haiku 4.5)
+    #   3. `@claude` in a PR comment (conversational, Sonnet 4.6)
     if: |
       (github.event_name == 'pull_request' &&
        github.event.action == 'labeled' &&
-       github.event.label.name == 'claude-review') ||
+       (github.event.label.name == 'claude-review' ||
+        github.event.label.name == 'claude-quick')) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
        contains(github.event.comment.body, '@claude'))
@@ -34,13 +36,18 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Model routing:
+          #   claude-review label -> Opus 4.7   (deep analysis)
+          #   claude-quick  label -> Haiku 4.5  (cheap triage)
+          #   @claude comments    -> Sonnet 4.6 (conversational default)
           claude_args: |
+            --model ${{ (github.event.label.name == 'claude-review') && 'claude-opus-4-7' || (github.event.label.name == 'claude-quick') && 'claude-haiku-4-5-20251001' || 'claude-sonnet-4-6' }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh api:*),Read,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
             EVENT: ${{ github.event_name }}
-            TRIGGER: ${{ github.event_name == 'pull_request' && 'label-applied' || 'at-claude-comment' }}
+            TRIGGER: ${{ github.event_name == 'pull_request' && format('label-{0}', github.event.label.name) || 'at-claude-comment' }}
             COMMENT BODY: ${{ github.event.comment.body }}
 
             FIRST ACTION (mandatory): read the review rules file at
@@ -48,12 +55,14 @@ jobs:
             source of truth for persona, intent routing, dedup contract, anti-speculation,
             style, focus areas, and skip list.
 
-            If TRIGGER is `label-applied`, treat this as an explicit FULL REVIEW request
-            (same as the "review request" intent in REVIEW_RULES.md).
-
-            If TRIGGER is `at-claude-comment`, route based on COMMENT BODY per
-            REVIEW_RULES.md Step 2 (review / question / disagreement / re-review /
-            clarification / chit-chat).
+            TRIGGER-TO-INTENT MAPPING:
+              - TRIGGER `label-claude-review` -> FULL REVIEW (deep, thorough, up to 6 inline comments)
+              - TRIGGER `label-claude-quick`  -> QUICK REVIEW: scan the diff in one pass, post at most
+                  2 high-signal inline comments OR a single "LGTM" top-level if nothing is flagged.
+                  Skip any finding that isn't immediately obvious. Fast triage pass.
+              - TRIGGER `at-claude-comment`   -> route based on COMMENT BODY per
+                  REVIEW_RULES.md Step 2 (review / question / disagreement / re-review /
+                  clarification / chit-chat).
 
             Do not improvise review behavior outside what REVIEW_RULES.md specifies.
             If REVIEW_RULES.md is missing, post a single `gh pr comment` saying so and exit.


### PR DESCRIPTION
Three-tier model routing based on task complexity:

| Trigger | Model | Use |
|---|---|---|
| Label `claude-review` | Opus 4.7 | Deep review on non-trivial PRs |
| Label `claude-quick` (new) | Haiku 4.5 | Fast triage — LGTM / obvious issues only |
| `@claude` in comments | Sonnet 4.6 | Conversation, Q&A, disagreement, re-review |

- Adds second label `claude-quick` (already created in repo).
- Workflow uses a YAML ternary to pick `--model` based on `github.event.label.name`.
- REVIEW_RULES.md cheatsheet updated with the tier table and a prompt-level instruction that `claude-quick` trigger must produce at most 2 inline comments or a single LGTM.

Rationale: Opus for deep thinking (races / subtle correctness) where its edge matters, Haiku for cheap scans where a heavier model is overkill, Sonnet as the conversational default. Saves Max quota on the long tail of trivial PRs while preserving full depth when explicitly requested.