### PR TITLE
[Manual Test] diffusion endpoints allow model mismatch (upstream #2805)

### DIFF
--- a/tests/entrypoints/openai_api/test_image_server.py
+++ b/tests/entrypoints/openai_api/test_image_server.py
@@ -679,6 +679,19 @@ def test_model_field_omitted_works(test_client):
     assert response.status_code == 200
 
 
+def test_generate_images_rejects_model_mismatch(test_client):
+    response = test_client.post(
+        "/v1/images/generations",
+        json={
+            "prompt": "test",
+            "model": "Qwen/Qwen-Image-2512",
+            "size": "1024x1024",
+        },
+    )
+    assert response.status_code == 400
+    assert "model mismatch" in response.json()["detail"].lower()
+
+
 def make_test_image_bytes(size=(64, 64)) -> bytes:
     img = Image.new(
         "RGB",
@@ -780,6 +793,20 @@ def test_image_edit_rejects_multiple_images_when_model_does_not_support_them(asy
         response.json()["detail"] == "Received multiple input images. Only a single image is supported by this model."
     )
     assert engine.captured_prompt is None
+
+
+def test_image_edit_rejects_model_mismatch(test_client):
+    img_bytes = make_test_image_bytes((16, 16))
+    response = test_client.post(
+        "/v1/images/edits",
+        files=[("image", img_bytes)],
+        data={
+            "prompt": "edit me",
+            "model": "Qwen/Qwen-Image-Edit",
+        },
+    )
+    assert response.status_code == 400
+    assert "model mismatch" in response.json()["detail"].lower()
 
 
 def test_image_edit_parameter_pass(async_omni_test_client):

--- a/tests/entrypoints/openai_api/test_video_server.py
+++ b/tests/entrypoints/openai_api/test_video_server.py
@@ -564,6 +564,18 @@ def test_missing_prompt_returns_422(test_client):
     assert response.status_code == 422
 
 
+def test_video_generation_rejects_model_mismatch(test_client):
+    response = test_client.post(
+        "/v1/videos",
+        data={
+            "prompt": "bad model",
+            "model": "Wan-AI/Wan2.1-T2V-14B-Diffusers",
+        },
+    )
+    assert response.status_code == 400
+    assert "model mismatch" in response.json()["detail"].lower()
+
+
 def test_invalid_size_parse_returns_422(test_client):
     response = test_client.post(
         "/v1/videos",

--- a/vllm_omni/entrypoints/openai/api_server.py
+++ b/vllm_omni/entrypoints/openai/api_server.py
@@ -1304,11 +1304,10 @@ async def generate_images(request: ImageGenerationRequest, raw_request: Request)
     # Get engine client (AsyncOmni) from app state
     engine_client, model_name, stage_configs = _get_engine_and_model(raw_request)
 
-    # Validate model field (warn if mismatch, don't error)
     if request.model is not None and request.model != model_name:
-        logger.warning(
-            f"Model mismatch: request specifies '{request.model}' but "
-            f"server is running '{model_name}'. Using server model."
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail=(f"Model mismatch: request specifies '{request.model}' but server is running '{model_name}'."),
         )
 
     try:
@@ -1446,8 +1445,9 @@ async def edit_images(
     # 1. get engine and model
     engine_client, model_name, stage_configs = _get_engine_and_model(raw_request)
     if model is not None and model != model_name:
-        logger.warning(
-            f"Model mismatch: request specifies '{model}' but server is running '{model_name}'. Using server model."
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST.value,
+            detail=(f"Model mismatch: request specifies '{model}' but server is running '{model_name}'."),
         )
     # 2. get output format & compression
     output_format = _choose_output_format(output_format, background)
@@ -2136,10 +2136,12 @@ async def _parse_video_form(
         app_model_name, app_stage_configs = _resolve_video_runtime_context(raw_request)
         effective_model_name = handler.model_name or app_model_name or request.model or "unknown"
         if request.model is not None and effective_model_name is not None and request.model != effective_model_name:
-            logger.warning(
-                "Model mismatch: request specifies '%s' but server is running '%s'. Using server model.",
-                request.model,
-                effective_model_name,
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST.value,
+                detail=(
+                    f"Model mismatch: request specifies '{request.model}' but server is running "
+                    f"'{effective_model_name}'."
+                ),
             )
         handler.set_stage_configs_if_missing(app_stage_configs)
     except HTTPException:


### PR DESCRIPTION
Manual test of the 3-tier model routing.

## How to use

Apply **one of these labels** to kick off a review:

| Label | Model | When |
|---|---|---|
| `claude-review` | Opus 4.7 | Deep review |
| `claude-quick` | Haiku 4.5 | Fast LGTM-style triage |

Then in comments, talk to the reviewer:

- `@claude review` — full review (Sonnet)
- `@claude why did you flag X?` — question (Sonnet)
- `@claude I disagree — Y handles that` — disagreement (Sonnet)
- `@claude LGTM?` — short verdict (Sonnet)
- `@claude look again after my fix` — re-review (Sonnet)

## Good comparison experiment

1. Apply `claude-quick` first → Haiku does a fast scan
2. Then apply `claude-review` → Opus does a deep pass
3. Compare the two results

Mirrors upstream vllm-project/vllm-omni#2805 (`[Bugfix] diffusion endpoints allow model mismatch` — 3 files / 61 lines). Do not merge.