### PR TITLE
Label-only trigger: disable @claude, 3 tiers via 3 labels

### DIFF
--- a/.github/REVIEW_RULES.md
+++ b/.github/REVIEW_RULES.md
@@ -4,26 +4,15 @@ This file is read by `.github/workflows/claude-review.yml` on every run. Edit th
 
 ## How to use this bot (for contributors and maintainers)
 
-The bot does NOT auto-review PRs. Trigger it explicitly. Three tiers, picked by trigger:
+The bot is triggered **only by labels**. Pick the tier that matches the PR:
 
-| Trigger | Model | Use for |
+| Label | Model | When to use |
 |---|---|---|
-| Label `claude-review` | **Opus 4.7** (deep) | Full review on non-trivial PRs — correctness, API design, perf, test gaps |
-| Label `claude-quick` | **Haiku 4.5** (cheap) | Fast triage — LGTM check on tiny PRs, obvious-issues-only scan |
-| `@claude <anything>` in a PR comment | **Sonnet 4.6** (balanced) | Conversation — follow-up questions, disagreement, re-review |
+| `claude-deep` | **Opus 4.7** (deepest) | Critical/complex PRs — subtle correctness, concurrency, cross-file invariants, perf-critical paths |
+| `claude-review` | **Sonnet 4.6** (balanced) | Default choice. Most PRs should use this — bugfixes, features, test additions |
+| `claude-quick` | **Haiku 4.5** (cheap/fast) | Tiny PRs, LGTM checks, obvious-issues-only triage |
 
-### `@claude` command menu (all Sonnet)
-
-| Say | Bot does |
-|---|---|
-| `@claude review` / `ptal` / `take a look` | Full review |
-| `@claude why did you flag X?` | Answer the question, no re-review |
-| `@claude I disagree — Y handles that` | Re-examine its prior comment |
-| `@claude look again after my fix` | Review only what changed |
-| `@claude LGTM?` | Short verdict |
-| `@claude` alone / "thanks" / "👍" | 1-line reply |
-
-Rule of thumb: **label = kick off review (pick tier by PR weight), `@claude` = talk to the reviewer**.
+The bot does **not** respond to `@claude` mentions. One trigger mechanism = simpler UX. Re-apply a label (or apply a different tier) to re-trigger.
 
 ## Who you are
 
@@ -56,19 +45,18 @@ Then internally (do NOT post this) enumerate every prior `claude[bot]` comment b
 - Each new comment must be a NET-NEW observation vs the already-said set.
 - NEVER re-review a PR you already reviewed unless the thread explicitly asks for another pass. If the contributor pushed new commits addressing your comments, acknowledge briefly what's fixed and what's still open — don't re-post old findings.
 
-## Step 2 — Determine intent
+## Step 2 — Pick depth based on trigger
 
-Given the event type and comment body (supplied by the workflow), pick ONE mode:
+The workflow tells you which label fired (via the TRIGGER field). Adjust depth accordingly:
 
-| Signal | Mode |
+| Trigger | Depth |
 |---|---|
-| `pull_request` event | Full review |
-| Comment: "review this", "take a look", "any concerns?", "ptal" | Full review |
-| Comment: specific question ("how many files?", "why X?", "is this safe?") | Answer via `gh pr comment`. One short paragraph. No re-review. |
-| Comment: disagreement ("I don't think that's right", "but X handles it") | Re-examine your original comment. If user is right, say so plainly ("Hmm you're right, I missed that `foo` already handles it — retract"). If you still disagree, cite specific file/line. Never just repeat your earlier point. |
-| Comment: "pushed the fix", "addressed comments", force-push | Re-review only what changed. Be brief. |
-| PR is ambiguous | Ask ONE sharp question via `gh pr comment` before reviewing |
-| Chit-chat / thanks / just "@claude" | 1-line reply via `gh pr comment`. "np", "👍" style. |
+| `label-claude-deep` | Full review, up to 6 inline comments. Allow subtle cross-file concerns (still cite file:line per the anti-speculation rule). |
+| `label-claude-review` | Standard review, 2-5 inline comments. High-signal only. |
+| `label-claude-quick` | Triage pass. AT MOST 2 inline comments, or a single top-level "LGTM" if nothing obvious is flagged. |
+
+If the PR has already been reviewed (dedup set non-empty) and no new commits, post a single
+`gh pr comment` summarizing what's still open — don't re-post inline findings.
 
 ## Step 3 — How to post
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,8 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [labeled]
-  issue_comment:
-    types: [created]
 
 permissions:
   contents: read
@@ -16,18 +14,13 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Triggered ONLY by:
-    #   1. Label `claude-review` (deep review, Opus 4.7)
-    #   2. Label `claude-quick`  (fast triage, Haiku 4.5)
-    #   3. `@claude` in a PR comment (conversational, Sonnet 4.6)
+    # Triggered ONLY by applying one of three labels. `@claude` mentions are
+    # intentionally NOT a trigger — this keeps the UX simple: label = review.
     if: |
-      (github.event_name == 'pull_request' &&
-       github.event.action == 'labeled' &&
-       (github.event.label.name == 'claude-review' ||
-        github.event.label.name == 'claude-quick')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null &&
-       contains(github.event.comment.body, '@claude'))
+      github.event.action == 'labeled' &&
+      (github.event.label.name == 'claude-deep' ||
+       github.event.label.name == 'claude-review' ||
+       github.event.label.name == 'claude-quick')
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,32 +30,31 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Model routing:
-          #   claude-review label -> Opus 4.7   (deep analysis)
-          #   claude-quick  label -> Haiku 4.5  (cheap triage)
-          #   @claude comments    -> Sonnet 4.6 (conversational default)
+          #   claude-deep   -> Opus 4.7   (deepest, most expensive)
+          #   claude-review -> Sonnet 4.6 (balanced, default)
+          #   claude-quick  -> Haiku 4.5  (cheap triage)
           claude_args: |
-            --model ${{ (github.event.label.name == 'claude-review') && 'claude-opus-4-7' || (github.event.label.name == 'claude-quick') && 'claude-haiku-4-5-20251001' || 'claude-sonnet-4-6' }}
+            --model ${{ (github.event.label.name == 'claude-deep') && 'claude-opus-4-7' || (github.event.label.name == 'claude-quick') && 'claude-haiku-4-5-20251001' || 'claude-sonnet-4-6' }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh api:*),Read,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-            EVENT: ${{ github.event_name }}
-            TRIGGER: ${{ github.event_name == 'pull_request' && format('label-{0}', github.event.label.name) || 'at-claude-comment' }}
-            COMMENT BODY: ${{ github.event.comment.body }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            TRIGGER: label-${{ github.event.label.name }}
 
             FIRST ACTION (mandatory): read the review rules file at
             `.github/REVIEW_RULES.md` and follow every rule in it. That file is the
-            source of truth for persona, intent routing, dedup contract, anti-speculation,
-            style, focus areas, and skip list.
+            source of truth for persona, dedup contract, anti-speculation, style,
+            focus areas, and skip list.
 
             TRIGGER-TO-INTENT MAPPING:
-              - TRIGGER `label-claude-review` -> FULL REVIEW (deep, thorough, up to 6 inline comments)
-              - TRIGGER `label-claude-quick`  -> QUICK REVIEW: scan the diff in one pass, post at most
-                  2 high-signal inline comments OR a single "LGTM" top-level if nothing is flagged.
-                  Skip any finding that isn't immediately obvious. Fast triage pass.
-              - TRIGGER `at-claude-comment`   -> route based on COMMENT BODY per
-                  REVIEW_RULES.md Step 2 (review / question / disagreement / re-review /
-                  clarification / chit-chat).
+              - TRIGGER `label-claude-deep`   -> DEEP REVIEW: thorough pass, up to 6 inline
+                  comments, allow subtle correctness / cross-file concerns (but still honor
+                  the anti-speculation rule — cite file:line for any cross-file claim).
+              - TRIGGER `label-claude-review` -> STANDARD REVIEW: balanced pass, 2-5 inline
+                  comments, high-signal only.
+              - TRIGGER `label-claude-quick`  -> QUICK TRIAGE: single pass, AT MOST 2 inline
+                  comments OR a single "LGTM" top-level if nothing is flagged. Skip any
+                  finding that isn't immediately obvious.
 
             Do not improvise review behavior outside what REVIEW_RULES.md specifies.
             If REVIEW_RULES.md is missing, post a single `gh pr comment` saying so and exit.


### PR DESCRIPTION
Simplify bot UX to one trigger type (labels), three tiers:

| Label | Model |
|---|---|
| `claude-deep` (new) | Opus 4.7 |
| `claude-review` (remapped) | Sonnet 4.6 |
| `claude-quick` | Haiku 4.5 |

Changes:
- Workflow: drop `issue_comment` trigger entirely. Only `pull_request: [labeled]` fires the bot.
- Workflow: handle all three labels; `--model` picked by label name.
- REVIEW_RULES.md: replace `@claude` command menu with a label-tier table. Replace Step 2 intent routing with a depth-by-trigger table.

Rationale: dropping `@claude` trades conversation ability for a dead-simple mental model — one apply-a-label action, no hidden modes. The three tiers cover almost every real use case (Opus for scary PRs, Sonnet for normal, Haiku for tiny).