### PR TITLE
Config CI Fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ from vllm.distributed.parallel_state import cleanup_dist_env_and_memory
 from vllm.logger import init_logger
 from vllm.utils.network_utils import get_open_port
 
+from vllm_omni.config.stage_config import resolve_deploy_yaml
 from vllm_omni.entrypoints.omni import Omni
 from vllm_omni.inputs.data import OmniSamplingParams
 from vllm_omni.outputs import OmniRequestOutput
@@ -1587,8 +1588,9 @@ class OmniServerStageCli(OmniServer):
         self.stage_config_path = stage_config_path
         self.master_port = get_open_port()
         self.visible_device_list = self._load_visible_device_list(env_dict)
-        self.stage_runtime_devices = self._load_stage_runtime_devices(stage_config_path)
-        self.stage_ids = stage_ids or self._load_stage_ids(stage_config_path)
+        resolved_cfg = resolve_deploy_yaml(stage_config_path)
+        self.stage_runtime_devices = self._load_stage_runtime_devices(resolved_cfg)
+        self.stage_ids = stage_ids or self._load_stage_ids(resolved_cfg)
         if 0 not in self.stage_ids:
             raise ValueError(f"Stage CLI test requires stage_id=0 in config: {stage_config_path}")
         self.stage_procs: dict[int, subprocess.Popen] = {}
@@ -1601,22 +1603,18 @@ class OmniServerStageCli(OmniServer):
         return cfg.get("stage_args") or cfg.get("stages") or []
 
     @staticmethod
-    def _load_stage_ids(stage_config_path: str) -> list[int]:
-        with open(stage_config_path, encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
-        stage_ids = [stage["stage_id"] for stage in OmniServerStageCli._stage_entries(cfg) if "stage_id" in stage]
+    def _load_stage_ids(resolved_config: dict) -> list[int]:
+        stage_ids = [
+            stage["stage_id"] for stage in OmniServerStageCli._stage_entries(resolved_config) if "stage_id" in stage
+        ]
         if not stage_ids:
-            raise ValueError(f"No stage IDs found in config: {stage_config_path}")
+            raise ValueError("No stage IDs found in resolved config")
         return stage_ids
 
     @staticmethod
-    def _load_stage_runtime_devices(stage_config_path: str) -> dict[int, str]:
-        with open(stage_config_path, encoding="utf-8") as f:
-            cfg = yaml.safe_load(f) or {}
-
+    def _load_stage_runtime_devices(resolved_config: dict) -> dict[int, str]:
         runtime_devices: dict[int, str] = {}
-        for stage in OmniServerStageCli._stage_entries(cfg):
+        for stage in OmniServerStageCli._stage_entries(resolved_config):
             stage_id = stage.get("stage_id")
             # New schema: stage.devices is flat at stage level.
             # Legacy schema: stage.runtime.devices is nested.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -184,6 +184,7 @@ _CI_OVERLAYS: dict[str, dict[str, Any]] = {
     },
     # Single-stage thinker-only topology for the abort test.
     "qwen2_5_omni_thinker_only": {
+        "async_chunk": False,
         "pipeline": "qwen2_5_omni_thinker_only",
         "stages": [
             {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,6 +35,7 @@ _CI_GENERATED_DIR = _REPO_ROOT / "tests" / ".ci_generated"
 _CI_OVERLAYS: dict[str, dict[str, Any]] = {
     "qwen2_5_omni": {
         "base_config": "qwen2_5_omni.yaml",
+        "async_chunk": False,
         "stages": [
             {
                 "stage_id": 0,
@@ -97,6 +98,7 @@ _CI_OVERLAYS: dict[str, dict[str, Any]] = {
     },
     "qwen3_omni_moe": {
         "base_config": "qwen3_omni_moe.yaml",
+        "async_chunk": False,
         "stages": [
             {
                 "stage_id": 0,

--- a/vllm_omni/config/stage_config.py
+++ b/vllm_omni/config/stage_config.py
@@ -391,7 +391,7 @@ def _merge_platforms(
     return merged
 
 
-def _resolve_deploy_yaml(path: str | Path) -> dict[str, Any]:
+def resolve_deploy_yaml(path: str | Path) -> dict[str, Any]:
     """Load a deploy YAML with optional ``base_config`` inheritance."""
     raw_dict = to_dict(load_yaml_config(path))
 
@@ -401,7 +401,7 @@ def _resolve_deploy_yaml(path: str | Path) -> dict[str, Any]:
 
     # Resolve relative to the overlay file's directory
     base_path = Path(path).parent / base_path
-    base_dict = _resolve_deploy_yaml(base_path)
+    base_dict = resolve_deploy_yaml(base_path)
 
     # Merge top-level scalars: overlay wins. ``stages:`` and ``platforms:``
     # are deep-merged below so an overlay can layer on top of the base.
@@ -419,7 +419,7 @@ def _resolve_deploy_yaml(path: str | Path) -> dict[str, Any]:
 
 def load_deploy_config(path: str | Path) -> DeployConfig:
     """Load a deploy YAML (with optional base_config inheritance)."""
-    raw_dict = _resolve_deploy_yaml(path)
+    raw_dict = resolve_deploy_yaml(path)
 
     stages = [_parse_stage_deploy(s) for s in raw_dict.get("stages", [])]
 

--- a/vllm_omni/deploy/qwen3_omni_moe.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe.yaml
@@ -24,8 +24,6 @@ stages:
   - stage_id: 0
     gpu_memory_utilization: 0.9
     devices: "0"
-    output_connectors:
-      to_stage_1: connector_of_shared_memory
     default_sampling_params:
       temperature: 0.4
       top_p: 0.9
@@ -39,8 +37,6 @@ stages:
     devices: "1"
     input_connectors:
       from_stage_0: connector_of_shared_memory
-    output_connectors:
-      to_stage_2: connector_of_shared_memory
     default_sampling_params:
       temperature: 0.9
       top_k: 50

--- a/vllm_omni/deploy/qwen3_omni_moe.yaml
+++ b/vllm_omni/deploy/qwen3_omni_moe.yaml
@@ -39,6 +39,8 @@ stages:
     devices: "1"
     input_connectors:
       from_stage_0: connector_of_shared_memory
+    output_connectors:
+      to_stage_2: connector_of_shared_memory
     default_sampling_params:
       temperature: 0.9
       top_k: 50
@@ -53,6 +55,8 @@ stages:
     async_scheduling: false
     max_num_batched_tokens: 51200
     devices: "1"
+    input_connectors:
+      from_stage_1: connector_of_shared_memory
     default_sampling_params:
       temperature: 0.0
       top_p: 1.0


### PR DESCRIPTION
Some small changes in the configs for CI fixes 🤞 


- Sets the overlays in the tests to use `async_chunk=False`. It's not set in the stage configs in the current tests ([example](https://github.com/vllm-project/vllm-omni/blob/main/tests/e2e/stage_configs/qwen3_omni_ci.yaml)), so it's resolving to `False` on `main`. So setting it in the test overlay so that we keep the same behavior (for `🌕 Omni · Doc Test with H100`)
- Fixes the graph connector edge in the Qwen3 omni config (for `🌕 Omni · Doc Test with L4`)
- Resolves the config before running the CLI test (and makes `resolve_deploy_yaml` public). If the child config doesn't explicitly set the devices, we have to resolve it first so that we can get the devices, otherwise the devices can be left unset, which can cause things to all land on the same stage and OOM (for `🌕 Omni · Function Test`)
- Adds `async_chunk=False` for the thinker only config (for [engine abort test](https://buildkite.com/vllm/vllm-omni/builds/7156/steps/canvas?sid=019d9dde-49cc-4d13-a907-4a78354fe20c&tab=output))