### PR TITLE
[Bugfix] enable `CUDNN_ATTN` on LTX-2.0 by setting explicit `head_dim`

### DIFF
--- a/benchmarks/diffusion/bench_e2e_ltx2.sh
+++ b/benchmarks/diffusion/bench_e2e_ltx2.sh
@@ -62,9 +62,7 @@ for BACKEND in "${BACKENDS[@]}"; do
   if [[ "${ENFORCE_EAGER:-0}" == "1" ]]; then
     EXTRA_ARGS+=(--enforce-eager)
   fi
-  # Run each backend in its own subshell with pipefail off so a non-zero
-  # python exit (e.g. example-script post-processing error after the timing
-  # has been printed) doesn't abort the sweep before the next backend runs.
+  # Per-backend pipefail off so a non-zero python exit doesn't abort the sweep.
   ( set +e; set +o pipefail
     DIFFUSION_ATTENTION_BACKEND="$BACKEND" \
       python examples/offline_inference/text_to_video/text_to_video.py \

--- a/benchmarks/diffusion/bench_e2e_ltx2.sh
+++ b/benchmarks/diffusion/bench_e2e_ltx2.sh
@@ -29,11 +29,18 @@ FPS="${FPS:-48}"
 SEED="${SEED:-42}"
 CFG_PARALLEL_SIZE="${CFG_PARALLEL_SIZE:-2}"
 
-BACKENDS=(
-  TORCH_SDPA
-  CUDNN_ATTN
-  FLASHINFER_ATTN
-)
+if [[ -n "${BACKENDS:-}" ]]; then
+  # shellcheck disable=SC2206
+  BACKENDS=( ${BACKENDS} )
+elif [[ -n "${DIFFUSION_ATTENTION_BACKEND:-}" ]]; then
+  BACKENDS=( "${DIFFUSION_ATTENTION_BACKEND}" )
+else
+  BACKENDS=(
+    TORCH_SDPA
+    CUDNN_ATTN
+    FLASHINFER_ATTN
+  )
+fi
 
 OUT_DIR="${OUT_DIR:-bench_ltx2_out}"
 mkdir -p "$OUT_DIR"
@@ -48,20 +55,34 @@ for BACKEND in "${BACKENDS[@]}"; do
   echo "======================================================================"
   echo "Running $BACKEND (CFG parallel ${CFG_PARALLEL_SIZE}) ..."
   echo "======================================================================"
-  DIFFUSION_ATTENTION_BACKEND="$BACKEND" \
-    python examples/offline_inference/text_to_video/text_to_video.py \
-      --model "$MODEL" \
-      --prompt "$PROMPT" \
-      --height "$HEIGHT" \
-      --width "$WIDTH" \
-      --num-frames "$FRAMES" \
-      --guidance-scale "$GUIDANCE" \
-      --frame-rate "$FRAME_RATE" \
-      --num-inference-steps "$STEPS" \
-      --fps "$FPS" \
-      --seed "$SEED" \
-      --cfg-parallel-size "$CFG_PARALLEL_SIZE" \
-      --output "$VID" 2>&1 | tee "$LOG"
+  EXTRA_ARGS=()
+  if [[ -n "${MODEL_CLASS_NAME:-}" ]]; then
+    EXTRA_ARGS+=(--model-class-name "$MODEL_CLASS_NAME")
+  fi
+  if [[ "${ENFORCE_EAGER:-0}" == "1" ]]; then
+    EXTRA_ARGS+=(--enforce-eager)
+  fi
+  # Run each backend in its own subshell with pipefail off so a non-zero
+  # python exit (e.g. example-script post-processing error after the timing
+  # has been printed) doesn't abort the sweep before the next backend runs.
+  ( set +e; set +o pipefail
+    DIFFUSION_ATTENTION_BACKEND="$BACKEND" \
+      python examples/offline_inference/text_to_video/text_to_video.py \
+        --model "$MODEL" \
+        --prompt "$PROMPT" \
+        --height "$HEIGHT" \
+        --width "$WIDTH" \
+        --num-frames "$FRAMES" \
+        --guidance-scale "$GUIDANCE" \
+        --frame-rate "$FRAME_RATE" \
+        --num-inference-steps "$STEPS" \
+        --fps "$FPS" \
+        --seed "$SEED" \
+        --cfg-parallel-size "$CFG_PARALLEL_SIZE" \
+        --tensor-parallel-size 1 \
+        "${EXTRA_ARGS[@]}" \
+        --output "$VID" 2>&1 | tee "$LOG"
+  ) || echo "[bench] $BACKEND exited non-zero — continuing"
 
   TOTAL=$(grep -oE "Total generation time: [0-9.]+" "$LOG" | awk '{print $4}' | tail -1)
   STEP=$(grep -oE "[0-9]+\.[0-9]+s/it" "$LOG" | tail -1 | sed 's/s\/it//')

--- a/benchmarks/diffusion/bench_e2e_ltx2.sh
+++ b/benchmarks/diffusion/bench_e2e_ltx2.sh
@@ -29,18 +29,11 @@ FPS="${FPS:-48}"
 SEED="${SEED:-42}"
 CFG_PARALLEL_SIZE="${CFG_PARALLEL_SIZE:-2}"
 
-if [[ -n "${BACKENDS:-}" ]]; then
-  # shellcheck disable=SC2206
-  BACKENDS=( ${BACKENDS} )
-elif [[ -n "${DIFFUSION_ATTENTION_BACKEND:-}" ]]; then
-  BACKENDS=( "${DIFFUSION_ATTENTION_BACKEND}" )
-else
-  BACKENDS=(
-    TORCH_SDPA
-    CUDNN_ATTN
-    FLASHINFER_ATTN
-  )
-fi
+BACKENDS=(
+  TORCH_SDPA
+  CUDNN_ATTN
+  FLASHINFER_ATTN
+)
 
 OUT_DIR="${OUT_DIR:-bench_ltx2_out}"
 mkdir -p "$OUT_DIR"
@@ -55,32 +48,20 @@ for BACKEND in "${BACKENDS[@]}"; do
   echo "======================================================================"
   echo "Running $BACKEND (CFG parallel ${CFG_PARALLEL_SIZE}) ..."
   echo "======================================================================"
-  EXTRA_ARGS=()
-  if [[ -n "${MODEL_CLASS_NAME:-}" ]]; then
-    EXTRA_ARGS+=(--model-class-name "$MODEL_CLASS_NAME")
-  fi
-  if [[ "${ENFORCE_EAGER:-0}" == "1" ]]; then
-    EXTRA_ARGS+=(--enforce-eager)
-  fi
-  # Per-backend pipefail off so a non-zero python exit doesn't abort the sweep.
-  ( set +e; set +o pipefail
-    DIFFUSION_ATTENTION_BACKEND="$BACKEND" \
-      python examples/offline_inference/text_to_video/text_to_video.py \
-        --model "$MODEL" \
-        --prompt "$PROMPT" \
-        --height "$HEIGHT" \
-        --width "$WIDTH" \
-        --num-frames "$FRAMES" \
-        --guidance-scale "$GUIDANCE" \
-        --frame-rate "$FRAME_RATE" \
-        --num-inference-steps "$STEPS" \
-        --fps "$FPS" \
-        --seed "$SEED" \
-        --cfg-parallel-size "$CFG_PARALLEL_SIZE" \
-        --tensor-parallel-size 1 \
-        "${EXTRA_ARGS[@]}" \
-        --output "$VID" 2>&1 | tee "$LOG"
-  ) || echo "[bench] $BACKEND exited non-zero — continuing"
+  DIFFUSION_ATTENTION_BACKEND="$BACKEND" \
+    python examples/offline_inference/text_to_video/text_to_video.py \
+      --model "$MODEL" \
+      --prompt "$PROMPT" \
+      --height "$HEIGHT" \
+      --width "$WIDTH" \
+      --num-frames "$FRAMES" \
+      --guidance-scale "$GUIDANCE" \
+      --frame-rate "$FRAME_RATE" \
+      --num-inference-steps "$STEPS" \
+      --fps "$FPS" \
+      --seed "$SEED" \
+      --cfg-parallel-size "$CFG_PARALLEL_SIZE" \
+      --output "$VID" 2>&1 | tee "$LOG"
 
   TOTAL=$(grep -oE "Total generation time: [0-9.]+" "$LOG" | awk '{print $4}' | tail -1)
   STEP=$(grep -oE "[0-9]+\.[0-9]+s/it" "$LOG" | tail -1 | sed 's/s\/it//')

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -428,9 +428,9 @@ class DiffusionEngine:
         }
         # Audio pipelines round audio token count from num_frames; the default
         # of 1 yields seq_len=1 K/V which cuDNN SDPA refuses under torch.compile
-        # (#3121). Pick a non-trivial num_frames so audio_num_frames > 1.
+        # (#3121). 2 is the minimum that produces audio_num_frames > 1.
         num_frames = (
-            24
+            2
             if supports_audio_input(self.od_config.model_class_name)
             or supports_audio_output(self.od_config.model_class_name)
             else 1

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -439,14 +439,9 @@ class DiffusionEngine:
             # validation when cfg_parallel_size > 1.
             extra_args={"cfg_text_scale": 1.0, "cfg_img_scale": 1.0},
         )
-        # Audio-bearing models (LTX-2/2.3) round their audio token count from
-        # num_frames. The default num_frames=1 yields audio_num_frames=1, which
-        # cuDNN SDPA rejects ("does not support key/value sequence length 1")
-        # under torch.compile — Dynamo wraps the dispatch failure before the
-        # runtime fallback in cudnn_attn.forward_cuda can fire (issue #3121).
-        # Use a non-trivial num_frames whenever the pipeline produces or
-        # accepts audio so the warmup graph hits realistic audio attention
-        # shapes.
+        # Audio pipelines round audio token count from num_frames; the default
+        # of 1 yields seq_len=1 K/V which cuDNN SDPA refuses under torch.compile
+        # (#3121). Pick a non-trivial num_frames so audio_num_frames > 1.
         if supports_audio_input(self.od_config.model_class_name) or supports_audio_output(
             self.od_config.model_class_name
         ):

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -426,22 +426,36 @@ class DiffusionEngine:
             "prompt": "dummy run",
             "multi_modal_data": {"image": dummy_image, "audio": dummy_audio},
         }
+        sampling_kwargs: dict[str, Any] = dict(
+            height=height,
+            width=width,
+            num_inference_steps=num_inference_steps,
+            # Keep warmup path minimal and robust across text encoders.
+            # Some models may fail when warmup implicitly triggers
+            # classifier-free guidance with an empty negative prompt.
+            guidance_scale=0.0,
+            num_outputs_per_prompt=1,
+            # Disable CFG for warmup to avoid triggering CFG parallel
+            # validation when cfg_parallel_size > 1.
+            extra_args={"cfg_text_scale": 1.0, "cfg_img_scale": 1.0},
+        )
+        # Audio-bearing models (LTX-2/2.3) round their audio token count from
+        # num_frames. The default num_frames=1 yields audio_num_frames=1, which
+        # cuDNN SDPA rejects ("does not support key/value sequence length 1")
+        # under torch.compile — Dynamo wraps the dispatch failure before the
+        # runtime fallback in cudnn_attn.forward_cuda can fire (issue #3121).
+        # Use a non-trivial num_frames whenever the pipeline produces or
+        # accepts audio so the warmup graph hits realistic audio attention
+        # shapes.
+        if supports_audio_input(self.od_config.model_class_name) or supports_audio_output(
+            self.od_config.model_class_name
+        ):
+            sampling_kwargs["num_frames"] = 24
+
         req = OmniDiffusionRequest(
             prompts=[prompt],
             request_ids=["dummy_req_id"],
-            sampling_params=OmniDiffusionSamplingParams(
-                height=height,
-                width=width,
-                num_inference_steps=num_inference_steps,
-                # Keep warmup path minimal and robust across text encoders.
-                # Some models may fail when warmup implicitly triggers
-                # classifier-free guidance with an empty negative prompt.
-                guidance_scale=0.0,
-                num_outputs_per_prompt=1,
-                # Disable CFG for warmup to avoid triggering CFG parallel
-                # validation when cfg_parallel_size > 1.
-                extra_args={"cfg_text_scale": 1.0, "cfg_img_scale": 1.0},
-            ),
+            sampling_params=OmniDiffusionSamplingParams(**sampling_kwargs),
         )
         logger.info("dummy run to warm up the model")
         request = self.pre_process_func(req) if self.pre_process_func is not None else req

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -428,7 +428,7 @@ class DiffusionEngine:
         }
         # Audio pipelines round audio token count from num_frames; the default
         # of 1 yields seq_len=1 K/V which cuDNN SDPA refuses under torch.compile
-        # (#3121). 2 is the minimum that produces audio_num_frames > 1.
+        # 2 is the minimum that produces audio_num_frames > 1.
         num_frames = (
             2
             if supports_audio_input(self.od_config.model_class_name)

--- a/vllm_omni/diffusion/diffusion_engine.py
+++ b/vllm_omni/diffusion/diffusion_engine.py
@@ -426,31 +426,32 @@ class DiffusionEngine:
             "prompt": "dummy run",
             "multi_modal_data": {"image": dummy_image, "audio": dummy_audio},
         }
-        sampling_kwargs: dict[str, Any] = dict(
-            height=height,
-            width=width,
-            num_inference_steps=num_inference_steps,
-            # Keep warmup path minimal and robust across text encoders.
-            # Some models may fail when warmup implicitly triggers
-            # classifier-free guidance with an empty negative prompt.
-            guidance_scale=0.0,
-            num_outputs_per_prompt=1,
-            # Disable CFG for warmup to avoid triggering CFG parallel
-            # validation when cfg_parallel_size > 1.
-            extra_args={"cfg_text_scale": 1.0, "cfg_img_scale": 1.0},
-        )
         # Audio pipelines round audio token count from num_frames; the default
         # of 1 yields seq_len=1 K/V which cuDNN SDPA refuses under torch.compile
         # (#3121). Pick a non-trivial num_frames so audio_num_frames > 1.
-        if supports_audio_input(self.od_config.model_class_name) or supports_audio_output(
-            self.od_config.model_class_name
-        ):
-            sampling_kwargs["num_frames"] = 24
-
+        num_frames = (
+            24
+            if supports_audio_input(self.od_config.model_class_name)
+            or supports_audio_output(self.od_config.model_class_name)
+            else 1
+        )
         req = OmniDiffusionRequest(
             prompts=[prompt],
             request_ids=["dummy_req_id"],
-            sampling_params=OmniDiffusionSamplingParams(**sampling_kwargs),
+            sampling_params=OmniDiffusionSamplingParams(
+                height=height,
+                width=width,
+                num_inference_steps=num_inference_steps,
+                num_frames=num_frames,
+                # Keep warmup path minimal and robust across text encoders.
+                # Some models may fail when warmup implicitly triggers
+                # classifier-free guidance with an empty negative prompt.
+                guidance_scale=0.0,
+                num_outputs_per_prompt=1,
+                # Disable CFG for warmup to avoid triggering CFG parallel
+                # validation when cfg_parallel_size > 1.
+                extra_args={"cfg_text_scale": 1.0, "cfg_img_scale": 1.0},
+            ),
         )
         logger.info("dummy run to warm up the model")
         request = self.pre_process_func(req) if self.pre_process_func is not None else req

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -70,8 +70,13 @@ def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, tor
     out = (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
     return out
 
-def apply_split_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor], *, head_dim: int) -> torch.Tensor:
-def apply_split_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor], head_dim: int) -> torch.Tensor:
+
+def apply_split_rotary_emb(
+    x: torch.Tensor,
+    freqs: tuple[torch.Tensor, torch.Tensor],
+    *,
+    head_dim: int,
+) -> torch.Tensor:
     # `head_dim` is plumbed in (not inferred via `-1`) so SDPA shape stays static under torch.compile (#3121).
     cos, sin = freqs
 

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -64,30 +64,22 @@ def _make_rms_norm(hidden_size: int, *, eps: float, elementwise_affine: bool) ->
 
 def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
     cos, sin = freqs
-    # Concrete pair count instead of -1: Dynamo turns inferred dims into SymInts
-    # that cuDNN SDPA's selector then rejects under torch.compile (#3121).
-    pair_count = x.shape[2] // 2
-    x_real, x_imag = x.unflatten(2, (pair_count, 2)).unbind(-1)  # [B, S, C // 2]
+    # Concrete pair count instead of -1 keeps SDPA shape static under torch.compile (#3121).
+    x_real, x_imag = x.unflatten(2, (x.shape[2] // 2, 2)).unbind(-1)  # [B, S, C // 2]
     x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(2)
     out = (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
     return out
 
 
-def apply_split_rotary_emb(
-    x: torch.Tensor,
-    freqs: tuple[torch.Tensor, torch.Tensor],
-    *,
-    head_dim: int,
-) -> torch.Tensor:
-    # `head_dim` is passed in (rather than inferred via `-1`) so the SDPA shape
-    # stays concrete under torch.compile / cuDNN — see #3121.
+def apply_split_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor], head_dim: int) -> torch.Tensor:
+    # `head_dim` is plumbed in (not inferred via `-1`) so SDPA shape stays static under torch.compile (#3121).
     cos, sin = freqs
 
     x_dtype = x.dtype
     needs_reshape = False
     if x.ndim != 4 and cos.ndim == 4:
-        # cos is (#b, h, t, r) -> reshape x to (b, h, t, head_dim).
-        # The cos/sin batch dim may only be broadcastable, so take batch size from x.
+        # cos is (#b, h, t, r) -> reshape x to (b, h, t, dim_per_head)
+        # The cos/sin batch dim may only be broadcastable, so take batch size from x
         b = x.shape[0]
         _, h, t, _ = cos.shape
         x = x.reshape(b, t, h, head_dim).swapaxes(1, 2)
@@ -475,9 +467,7 @@ class LTX2AudioVideoAttnProcessor:
             elif attn.rope_type == "split":
                 query = apply_split_rotary_emb(query, query_rotary_emb, head_dim=attn.head_dim)
                 key = apply_split_rotary_emb(
-                    key,
-                    key_rotary_emb if key_rotary_emb is not None else query_rotary_emb,
-                    head_dim=attn.head_dim,
+                    key, key_rotary_emb if key_rotary_emb is not None else query_rotary_emb, head_dim=attn.head_dim
                 )
 
         query = query.unflatten(2, (attn.heads, attn.head_dim))
@@ -1333,14 +1323,14 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
                 cos_freq = torch.concatenate([cos_padding, cos_freq], axis=-1)
                 sin_freq = torch.concatenate([sin_padding, sin_freq], axis=-1)
 
-            # Reshape freqs to be compatible with multi-head attention.
-            # Concrete per-head dim — see apply_split_rotary_emb (#3121).
+            # Reshape freqs to be compatible with multi-head attention
             b = cos_freq.shape[0]
             t = cos_freq.shape[1]
-            freq_dim_per_head = self.dim // self.num_attention_heads // 2
+            # Concrete per-head dim instead of -1 — see apply_split_rotary_emb (#3121)
+            r = self.dim // self.num_attention_heads // 2
 
-            cos_freq = cos_freq.reshape(b, t, self.num_attention_heads, freq_dim_per_head)
-            sin_freq = sin_freq.reshape(b, t, self.num_attention_heads, freq_dim_per_head)
+            cos_freq = cos_freq.reshape(b, t, self.num_attention_heads, r)
+            sin_freq = sin_freq.reshape(b, t, self.num_attention_heads, r)
 
             cos_freqs = torch.swapaxes(cos_freq, 1, 2)  # (B,H,T,D//2)
             sin_freqs = torch.swapaxes(sin_freq, 1, 2)  # (B,H,T,D//2)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -64,10 +64,8 @@ def _make_rms_norm(hidden_size: int, *, eps: float, elementwise_affine: bool) ->
 
 def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
     cos, sin = freqs
-    # Use a concrete pair count (x.shape[2] // 2) instead of unflatten's -1.
-    # Under torch.compile, -1 forces Dynamo to introduce a fresh SymInt for
-    # the inferred dim, which propagates as a symbolic head_dim through to
-    # SDPA and breaks cuDNN's kernel selection (issue #3121).
+    # Concrete pair count instead of -1: Dynamo turns inferred dims into SymInts
+    # that cuDNN SDPA's selector then rejects under torch.compile (#3121).
     pair_count = x.shape[2] // 2
     x_real, x_imag = x.unflatten(2, (pair_count, 2)).unbind(-1)  # [B, S, C // 2]
     x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(2)
@@ -81,16 +79,15 @@ def apply_split_rotary_emb(
     *,
     head_dim: int,
 ) -> torch.Tensor:
+    # `head_dim` is passed in (rather than inferred via `-1`) so the SDPA shape
+    # stays concrete under torch.compile / cuDNN — see #3121.
     cos, sin = freqs
 
     x_dtype = x.dtype
     needs_reshape = False
     if x.ndim != 4 and cos.ndim == 4:
-        # cos is (#b, h, t, r) -> reshape x to (b, h, t, head_dim)
+        # cos is (#b, h, t, r) -> reshape x to (b, h, t, head_dim).
         # The cos/sin batch dim may only be broadcastable, so take batch size from x.
-        # Use the concrete `head_dim` arg instead of `-1` here: under torch.compile,
-        # an inferred `-1` becomes a fresh SymInt that propagates to SDPA and
-        # makes cuDNN's kernel selector reject the call (issue #3121).
         b = x.shape[0]
         _, h, t, _ = cos.shape
         x = x.reshape(b, t, h, head_dim).swapaxes(1, 2)
@@ -120,8 +117,6 @@ def apply_split_rotary_emb(
     out = out.reshape(*out.shape[:-2], last)
 
     if needs_reshape:
-        # Same reasoning as above: avoid `-1` so the flattened total_dim
-        # stays concrete in the Dynamo trace.
         out = out.swapaxes(1, 2).reshape(b, t, h * head_dim)
 
     out = out.to(dtype=x_dtype)
@@ -1339,11 +1334,7 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
                 sin_freq = torch.concatenate([sin_padding, sin_freq], axis=-1)
 
             # Reshape freqs to be compatible with multi-head attention.
-            # Compute the per-head frequency width as a concrete Python int
-            # (self.dim and self.num_attention_heads are construction-time
-            # constants). Using `-1` here would let Dynamo infer it as a
-            # SymInt that propagates through SDPA and breaks cuDNN's kernel
-            # selection (issue #3121).
+            # Concrete per-head dim — see apply_split_rotary_emb (#3121).
             b = cos_freq.shape[0]
             t = cos_freq.shape[1]
             freq_dim_per_head = self.dim // self.num_attention_heads // 2

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -70,7 +70,7 @@ def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, tor
     out = (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
     return out
 
-
+def apply_split_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor], *, head_dim: int) -> torch.Tensor:
 def apply_split_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor], head_dim: int) -> torch.Tensor:
     # `head_dim` is plumbed in (not inferred via `-1`) so SDPA shape stays static under torch.compile (#3121).
     cos, sin = freqs

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -64,7 +64,7 @@ def _make_rms_norm(hidden_size: int, *, eps: float, elementwise_affine: bool) ->
 
 def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
     cos, sin = freqs
-    # Concrete pair count instead of -1 keeps SDPA shape static under torch.compile (#3121).
+    # Concrete pair count instead of -1 keeps SDPA shape static under torch.compile.
     x_real, x_imag = x.unflatten(2, (x.shape[2] // 2, 2)).unbind(-1)  # [B, S, C // 2]
     x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(2)
     out = (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
@@ -77,7 +77,7 @@ def apply_split_rotary_emb(
     *,
     head_dim: int,
 ) -> torch.Tensor:
-    # `head_dim` is plumbed in (not inferred via `-1`) so SDPA shape stays static under torch.compile (#3121).
+    # `head_dim` is plumbed in (not inferred via `-1`) so SDPA shape stays static under torch.compile.
     cos, sin = freqs
 
     x_dtype = x.dtype
@@ -1331,7 +1331,7 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
             # Reshape freqs to be compatible with multi-head attention
             b = cos_freq.shape[0]
             t = cos_freq.shape[1]
-            # Concrete per-head dim instead of -1 — see apply_split_rotary_emb (#3121)
+            # Concrete per-head dim instead of -1 — see apply_split_rotary_emb
             r = self.dim // self.num_attention_heads // 2
 
             cos_freq = cos_freq.reshape(b, t, self.num_attention_heads, r)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -466,9 +466,9 @@ class LTX2AudioVideoAttnProcessor:
                 query = apply_split_rotary_emb(query, query_rotary_emb)
                 key = apply_split_rotary_emb(key, key_rotary_emb if key_rotary_emb is not None else query_rotary_emb)
 
-        query = query.unflatten(2, (attn.heads, -1))
-        key = key.unflatten(2, (attn.heads, -1))
-        value = value.unflatten(2, (attn.heads, -1))
+        query = query.unflatten(2, (attn.heads, attn.head_dim))
+        key = key.unflatten(2, (attn.heads, attn.head_dim))
+        value = value.unflatten(2, (attn.heads, attn.head_dim))
 
         attn_metadata = AttentionMetadata(attn_mask=attention_mask) if attention_mask is not None else None
         hidden_states = attn.attn(query, key, value, attn_metadata)
@@ -477,7 +477,7 @@ class LTX2AudioVideoAttnProcessor:
 
         # LTX-2.3: per-head gated attention
         if attn.to_gate_logits is not None:
-            hidden_states = hidden_states.unflatten(2, (attn.heads, -1))  # [B, T, H, D]
+            hidden_states = hidden_states.unflatten(2, (attn.heads, attn.head_dim))  # [B, T, H, D]
             # 2.0 * sigmoid so zero-init gates produce 1.0 (identity)
             gates = 2.0 * torch.sigmoid(gate_logits)  # [B, T, H]
             hidden_states = hidden_states * gates.unsqueeze(-1)

--- a/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
+++ b/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py
@@ -64,23 +64,36 @@ def _make_rms_norm(hidden_size: int, *, eps: float, elementwise_affine: bool) ->
 
 def apply_interleaved_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
     cos, sin = freqs
-    x_real, x_imag = x.unflatten(2, (-1, 2)).unbind(-1)  # [B, S, C // 2]
+    # Use a concrete pair count (x.shape[2] // 2) instead of unflatten's -1.
+    # Under torch.compile, -1 forces Dynamo to introduce a fresh SymInt for
+    # the inferred dim, which propagates as a symbolic head_dim through to
+    # SDPA and breaks cuDNN's kernel selection (issue #3121).
+    pair_count = x.shape[2] // 2
+    x_real, x_imag = x.unflatten(2, (pair_count, 2)).unbind(-1)  # [B, S, C // 2]
     x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(2)
     out = (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
     return out
 
 
-def apply_split_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
+def apply_split_rotary_emb(
+    x: torch.Tensor,
+    freqs: tuple[torch.Tensor, torch.Tensor],
+    *,
+    head_dim: int,
+) -> torch.Tensor:
     cos, sin = freqs
 
     x_dtype = x.dtype
     needs_reshape = False
     if x.ndim != 4 and cos.ndim == 4:
-        # cos is (#b, h, t, r) -> reshape x to (b, h, t, dim_per_head)
-        # The cos/sin batch dim may only be broadcastable, so take batch size from x
+        # cos is (#b, h, t, r) -> reshape x to (b, h, t, head_dim)
+        # The cos/sin batch dim may only be broadcastable, so take batch size from x.
+        # Use the concrete `head_dim` arg instead of `-1` here: under torch.compile,
+        # an inferred `-1` becomes a fresh SymInt that propagates to SDPA and
+        # makes cuDNN's kernel selector reject the call (issue #3121).
         b = x.shape[0]
         _, h, t, _ = cos.shape
-        x = x.reshape(b, t, h, -1).swapaxes(1, 2)
+        x = x.reshape(b, t, h, head_dim).swapaxes(1, 2)
         needs_reshape = True
 
     # Split last dim (2*r) into (d=2, r)
@@ -107,7 +120,9 @@ def apply_split_rotary_emb(x: torch.Tensor, freqs: tuple[torch.Tensor, torch.Ten
     out = out.reshape(*out.shape[:-2], last)
 
     if needs_reshape:
-        out = out.swapaxes(1, 2).reshape(b, t, -1)
+        # Same reasoning as above: avoid `-1` so the flattened total_dim
+        # stays concrete in the Dynamo trace.
+        out = out.swapaxes(1, 2).reshape(b, t, h * head_dim)
 
     out = out.to(dtype=x_dtype)
     return out
@@ -463,8 +478,12 @@ class LTX2AudioVideoAttnProcessor:
                     key, key_rotary_emb if key_rotary_emb is not None else query_rotary_emb
                 )
             elif attn.rope_type == "split":
-                query = apply_split_rotary_emb(query, query_rotary_emb)
-                key = apply_split_rotary_emb(key, key_rotary_emb if key_rotary_emb is not None else query_rotary_emb)
+                query = apply_split_rotary_emb(query, query_rotary_emb, head_dim=attn.head_dim)
+                key = apply_split_rotary_emb(
+                    key,
+                    key_rotary_emb if key_rotary_emb is not None else query_rotary_emb,
+                    head_dim=attn.head_dim,
+                )
 
         query = query.unflatten(2, (attn.heads, attn.head_dim))
         key = key.unflatten(2, (attn.heads, attn.head_dim))
@@ -1319,12 +1338,18 @@ class LTX2AudioVideoRotaryPosEmbed(nn.Module):
                 cos_freq = torch.concatenate([cos_padding, cos_freq], axis=-1)
                 sin_freq = torch.concatenate([sin_padding, sin_freq], axis=-1)
 
-            # Reshape freqs to be compatible with multi-head attention
+            # Reshape freqs to be compatible with multi-head attention.
+            # Compute the per-head frequency width as a concrete Python int
+            # (self.dim and self.num_attention_heads are construction-time
+            # constants). Using `-1` here would let Dynamo infer it as a
+            # SymInt that propagates through SDPA and breaks cuDNN's kernel
+            # selection (issue #3121).
             b = cos_freq.shape[0]
             t = cos_freq.shape[1]
+            freq_dim_per_head = self.dim // self.num_attention_heads // 2
 
-            cos_freq = cos_freq.reshape(b, t, self.num_attention_heads, -1)
-            sin_freq = sin_freq.reshape(b, t, self.num_attention_heads, -1)
+            cos_freq = cos_freq.reshape(b, t, self.num_attention_heads, freq_dim_per_head)
+            sin_freq = sin_freq.reshape(b, t, self.num_attention_heads, freq_dim_per_head)
 
             cos_freqs = torch.swapaxes(cos_freq, 1, 2)  # (B,H,T,D//2)
             sin_freqs = torch.swapaxes(sin_freq, 1, 2)  # (B,H,T,D//2)

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -148,10 +148,7 @@ class _VideoAudioScheduler:
 
 
 class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
-    # The transformer jointly diffuses video + audio latents (audio_attn1 in
-    # LTX2VideoTransformerBlock fires unconditionally during forward), so the
-    # warmup needs realistic audio shapes to compile cleanly under
-    # torch.compile + cuDNN SDPA. See diffusion_engine._dummy_run.
+    # Audio is diffused jointly with video; warmup must size audio tokens (#3121).
     support_audio_output = True
 
     def __init__(

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -148,7 +148,7 @@ class _VideoAudioScheduler:
 
 
 class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
-    # Audio is diffused jointly with video; warmup must size audio tokens (#3121).
+    # Audio is diffused jointly with video; warmup must size audio tokens.
     support_audio_output = True
 
     def __init__(

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2.py
@@ -148,6 +148,12 @@ class _VideoAudioScheduler:
 
 
 class LTX2Pipeline(nn.Module, CFGParallelMixin, ProgressBarMixin):
+    # The transformer jointly diffuses video + audio latents (audio_attn1 in
+    # LTX2VideoTransformerBlock fires unconditionally during forward), so the
+    # warmup needs realistic audio shapes to compile cleanly under
+    # torch.compile + cuDNN SDPA. See diffusion_engine._dummy_run.
+    support_audio_output = True
+
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
@@ -115,10 +115,7 @@ class LTX23Pipeline(nn.Module, ProgressBarMixin):
     - CPU offloading: text encoder, connectors, VAE, vocoder stay on CPU
     """
 
-    # The transformer jointly diffuses video + audio latents (audio_attn1 in
-    # LTX2VideoTransformerBlock fires unconditionally during forward), so the
-    # warmup needs realistic audio shapes to compile cleanly under
-    # torch.compile + cuDNN SDPA. See diffusion_engine._dummy_run.
+    # Audio is diffused jointly with video; warmup must size audio tokens (#3121).
     support_audio_output = True
 
     def __init__(

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
@@ -115,6 +115,12 @@ class LTX23Pipeline(nn.Module, ProgressBarMixin):
     - CPU offloading: text encoder, connectors, VAE, vocoder stay on CPU
     """
 
+    # The transformer jointly diffuses video + audio latents (audio_attn1 in
+    # LTX2VideoTransformerBlock fires unconditionally during forward), so the
+    # warmup needs realistic audio shapes to compile cleanly under
+    # torch.compile + cuDNN SDPA. See diffusion_engine._dummy_run.
+    support_audio_output = True
+
     def __init__(
         self,
         *,

--- a/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
+++ b/vllm_omni/diffusion/models/ltx2/pipeline_ltx2_3.py
@@ -115,7 +115,7 @@ class LTX23Pipeline(nn.Module, ProgressBarMixin):
     - CPU offloading: text encoder, connectors, VAE, vocoder stay on CPU
     """
 
-    # Audio is diffused jointly with video; warmup must size audio tokens (#3121).
+    # Audio is diffused jointly with video; warmup must size audio tokens.
     support_audio_output = True
 
     def __init__(


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Latest Update [25 Apr]

Ready to merge

## Purpose

Closes #3121. The benefit of CuDNN to LTX-2.0 is about 1.07x faster inference. 

| Model | Shape | TORCH_SDPA | CUDNN_ATTN | FLASHINFER_ATTN | Best/Worst |
|---|---|---|---|---|---|
| LTX-2.0 (T2V+A) | 480p / 97f / 500 steps, **CFG=1** | 580.40 s | **543.01 s** | 546.96 s | 1.07× |


## Key Fix 
The q,k,v 's `head_dim` in `LTX2AudioVideoAttnProcessor` was calculated dynamically via `-1` in reshape. The `-1` will be passed over to SDPA like below, 

```
FakeTensor(..., size=(s47, 32, 1, ((s42*((1024//s42)))//16)), ...)
``` 
which will be derived to `64` during runtime, but cuDNN's SDPA kernel selector refuses these kind of operator-as-string expression. 

So the error can be reproduced as below. 

<details>

```
0%|          | 0/2 [00:00<?, ?it/s]/root/vllm-omni/.venv/lib/python3.12/site-packages/torch/_dynamo/utils.py:3694: UserWarning: Memory efficient kernel not used because: (Triggered internally at /pytorch/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp:960.)
0%|          | 0/2 [00:01<?, ?it/s]
ERROR 04-25 11:53:44 [diffusion_worker.py:920] Error executing method 'execute_model'. This might cause issues in distributed execution.
ERROR 04-25 11:53:44 [diffusion_worker.py:920] Traceback (most recent call last):
ERROR 04-25 11:53:44 [diffusion_worker.py:920]   ... <truncated Dynamo internals: torch/_dynamo/symbolic_convert.py, convert_frame.py> ...
ERROR 04-25 11:53:44 [diffusion_worker.py:920]   File "/root/vllm-omni/.venv/lib/python3.12/site-packages/torch/_dynamo/utils.py", line 3694, in run_node
ERROR 04-25 11:53:44 [diffusion_worker.py:920]     return node.target(*args, **kwargs)  # type: ignore[operator]
ERROR 04-25 11:53:44 [diffusion_worker.py:920] torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <built-in function scaled_dot_product_attention>(*(FakeTensor(..., device='cuda:0', size=(s47, 32, 1, ((s42*((1024//s42)))//16)),
ERROR 04-25 11:53:44 [diffusion_worker.py:920]            dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s47, 32, 1, ((s42*((1024//s42)))//16)),
ERROR 04-25 11:53:44 [diffusion_worker.py:920]            dtype=torch.bfloat16), FakeTensor(..., device='cuda:0', size=(s47, 32, 1, 64), dtype=torch.bfloat16)), **{'attn_mask': None, 'dropout_p': 0.0, 'is_causal': False, 'scale': 0.125000000000000}): got RuntimeError('No available kernel. Aborting execution.')
ERROR 04-25 11:53:44 [diffusion_worker.py:920]
ERROR 04-25 11:53:44 [diffusion_worker.py:920] from user code:
ERROR 04-25 11:53:44 [diffusion_worker.py:920]    File "/root/vllm-omni/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py", line 939, in forward
ERROR 04-25 11:53:44 [diffusion_worker.py:920]     attn_audio_hidden_states = self.audio_attn1(
ERROR 04-25 11:53:44 [diffusion_worker.py:920]   File "/root/vllm-omni/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py", line 704, in forward
ERROR 04-25 11:53:44 [diffusion_worker.py:920]     hidden_states = self.processor(
ERROR 04-25 11:53:44 [diffusion_worker.py:920]   File "/root/vllm-omni/vllm_omni/diffusion/models/ltx2/ltx2_transformer.py", line 474, in __call__
ERROR 04-25 11:53:44 [diffusion_worker.py:920]     hidden_states = attn.attn(query, key, value, attn_metadata)
ERROR 04-25 11:53:44 [diffusion_worker.py:920]   File "/root/vllm-omni/vllm_omni/diffusion/attention/layer.py", line 130, in forward
ERROR 04-25 11:53:44 [diffusion_worker.py:920]     out = self._run_local_attention(query, key, value, attn_metadata)
ERROR 04-25 11:53:44 [diffusion_worker.py:920]   File "/root/vllm-omni/vllm_omni/diffusion/attention/layer.py", line 147, in _run_local_attention
ERROR 04-25 11:53:44 [diffusion_worker.py:920]     return self.attention.forward(query, key, value, attn_metadata)
ERROR 04-25 11:53:44 [diffusion_worker.py:920]   File "/root/vllm-omni/vllm_omni/diffusion/attention/backends/abstract.py", line 97, in forward
ERROR 04-25 11:53:44 [diffusion_worker.py:920]     return self.forward_cuda(query, key, value, attn_metadata)
ERROR 04-25 11:53:44 [diffusion_worker.py:920]   File "/root/vllm-omni/vllm_omni/diffusion/attention/backends/cudnn_attn.py", line 79, in forward_cuda
ERROR 04-25 11:53:44 [diffusion_worker.py:920]     output = torch.nn.functional.scaled_dot_product_attention(
ERROR 04-25 11:53:44 [diffusion_worker.py:920]
ERROR 04-25 11:53:44 [diffusion_worker.py:920] Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
```

</details>

To fix it, just need to replace all usage of `-1` to explicit `head_dim=attn.head_dim`. 

Another minor issue is that for audio attention, cuDNN will raise error when `K/V seq_len == 1`. This invalid value was set for LTX-2.0 in `diffusion_engine._dummy_run`, but in real video generation, KV seq_len is > 1. (larger `num_frames` leads to longer KV seq_len. in real video gen tasks, `num_frames` was set to ~64). To fix it, we set `num_frames`=2  during dummy run, so `audio_num_frames >= 2` and then KV seq_len is > 1. 


## Test Plan

Jus rerun the script mentioned in original issue, 

```bash
MODEL=dg845/LTX-2.3-Diffusers \
MODEL_CLASS_NAME=LTX23Pipeline \
HEIGHT=512 WIDTH=768 \
FRAMES=81 FPS=24 FRAME_RATE=24 \
STEPS=10 GUIDANCE=4.0 \
DIFFUSION_ATTENTION_BACKEND=CUDNN_ATTN \
CFG_PARALLEL_SIZE=1 \
HF_TOKEN=<your_hf_token> \
bash benchmarks/diffusion/bench_e2e_ltx2.sh
```

## Test Result

The output becomes normal again, 

<details>

```
INFO 04-25 12:49:18 [diffusion_engine.py:460] dummy run to warm up the model
  0%|          | 0/2 [00:00<?, ?it/s]
 50%|█████     | 1/2 [00:32<00:32, 32.17s/it]
100%|██████████| 2/2 [00:32<00:00, 13.39s/it]
100%|██████████| 2/2 [00:32<00:00, 16.20s/it]
INFO 04-25 12:50:32 [diffusion_model_runner.py:213] Peak GPU memory (this request): 60.35 GB reserved, 59.76 GB allocated, 0.58 GB pool overhead (1.0%)
```

```
============================================================
Generation Configuration:
  Model: dg845/LTX-2.3-Diffusers
  Inference steps: 10
  Frames: 81
  Parallel configuration: ulysses_degree=1, ring_degree=1, cfg_parallel_size=1, tensor_parallel_size=1, vae_patch_parallel_size=1, enable_expert_parallel=False
  Video size: 768x512
============================================================

Processed prompts:   0%|          | 0/1 [00:00<?, ?it/s]
WARNING 04-25 12:50:32 [kv_transfer_manager.py:985] No connector available for receiving KV cache
  0%|          | 0/10 [00:00<?, ?it/s]
 10%|█         | 1/10 [00:02<00:21,  2.40s/it]
 20%|██        | 2/10 [00:03<00:11,  1.49s/it]
 30%|███       | 3/10 [00:04<00:08,  1.20s/it]
 40%|████      | 4/10 [00:04<00:06,  1.06s/it]
 50%|█████     | 5/10 [00:05<00:04,  1.01it/s]
 60%|██████    | 6/10 [00:06<00:03,  1.06it/s]
 70%|███████   | 7/10 [00:07<00:02,  1.10it/s]
 80%|████████  | 8/10 [00:08<00:01,  1.12it/s]
 90%|█████████ | 9/10 [00:09<00:00,  1.13it/s]
100%|██████████| 10/10 [00:10<00:00,  1.15it/s]
100%|██████████| 10/10 [00:10<00:00,  1.01s/it]

INFO 04-25 12:51:10 [diffusion_model_runner.py:213] Peak GPU memory (this request): 60.34 GB reserved, 59.76 GB allocated, 0.58 GB pool overhead (1.0%)
INFO 04-25 12:51:10 [diffusion_engine.py:127] Generation completed successfully.
INFO 04-25 12:51:10 [diffusion_engine.py:177] DiffusionEngine.step breakdown: preprocess=0.00 ms, add_req_and_wait=37608.85 ms, postprocess=0.16 ms, total=37609.16 ms
Processed prompts: 100%|██████████| 1/1 [00:37<00:00, 37.61s/it]
Total generation time: 37.6128 seconds (37612.80 ms)
```

</details>

Also I ran the same benchmark on LTX-2.0, with `480p / 97f / 500 steps`, but CFG is set to 1 because I only used 1 PRO 6000. 

| Model | Shape | TORCH_SDPA | CUDNN_ATTN | FLASHINFER_ATTN | Best/Worst |
|---|---|---|---|---|---|
| LTX-2.0 (T2V+A) | 480p / 97f / 500 steps, **CFG=1** | 580.40 s | **543.01 s** | 546.96 s | 1.07× |


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan. Please provide the test scripts & test commands. Please state the reasons if your codes don't require additional test scripts. For test file guidelines, please check the [test style doc](https://docs.vllm.ai/projects/vllm-omni/en/latest/contributing/ci/tests_style/)
- [ ] The test results. Please paste the results comparison before and after, or the e2e results.
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model. **Please run `mkdocs serve` to sync the documentation editions to `./docs`.**
- [ ] (Optional) Release notes update. If your change is user-facing, please update the release notes draft.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://github.com/vllm-project/vllm-omni/blob/main/CONTRIBUTING.md>** (anything written below this line will be removed by GitHub Actions)
